### PR TITLE
Add name attribute to <input> tags in `/login`

### DIFF
--- a/mainapp/templates/login.html
+++ b/mainapp/templates/login.html
@@ -9,22 +9,12 @@
     {% csrf_token %}
     <div class="form-group">
         <label for="username">Username</label>
-        <input type="text" class="form-control" id="username" placeholder="Enter your user name" required>
+        <input type="text" class="form-control" id="username" name="username" placeholder="Enter your user name" required>
     </div>
     <div class="form-group">
         <label for="password">Password</label>
-        <input type="password" class="form-control" id="password" placeholder="Password" required>
+        <input type="password" class="form-control" id="password" name ="password" placeholder="Password" required>
     </div>
-    <!--<ul>
-        <li>
-            <label for="username">Username</label>
-            <input type="text" name="username" id="username" required>
-        </li>
-        <li>
-            <label for="password">Password</label>
-            <input type="password" name="password" required>
-        </li>
-    </ul>-->
     <input type="submit" class="btn btn-primary" value="Login">
 </form>
 {% endblock %}


### PR DESCRIPTION
I found that after merging https://github.com/gcivil-nyu-org/fall2019-cs-gy-6063-team-five_fries/pull/87, `/login` was broken. (MultiValueDictKeyError)

To be specific, we cannot read username/password on the server-side. It seems it's because we removed name attribute from <input> tag.

https://stackoverflow.com/a/21799201/1556838

I thought `id` and `name` work in a similar way. That's why I approved #87 but it isn't