### PR TITLE
Trivial fixes on the search page

### DIFF
--- a/mainapp/tests.py
+++ b/mainapp/tests.py
@@ -11,7 +11,7 @@ class BaseTemplateTestCase(TestCase):
     def test_my_account_on_header(self):
         """If a user has been logged in, My Account should be shown in the header"""
         self.client.force_login(User.objects.get_or_create(username="testuser")[0])
-        response = self.client.get(reverse("index"))
+        response = self.client.get(reverse("search"))
         soup = BeautifulSoup(response.content, "html.parser")
         nav = soup.find("nav", class_="navbar")
         self.assertIn("My Account", nav.text)

--- a/mainapp/views.py
+++ b/mainapp/views.py
@@ -22,7 +22,10 @@ class LoginView(TemplateView):
 
 
 def index(request):
-    return render(request, "index.html")
+    if request.user.is_authenticated:
+        return HttpResponseRedirect(reverse("search"))
+    else:
+        return render(request, "index.html")
 
 
 def account(request):

--- a/search/forms.py
+++ b/search/forms.py
@@ -1,6 +1,1 @@
-from django import forms
-
-
-class ZillowSearchForm(forms.Form):
-    address = forms.CharField(label="address", max_length=100)
-    city_state_zip = forms.CharField(label="cityStateZip", max_length=100)
+# from django import forms

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -27,21 +27,6 @@ $(document).ready(function(){
                         <input type="submit" class="btn btn-primary" value="Go">
                     </form>
                 </div>
-                <div class="col-7">
-                    <h2>Search Zillow</h2>
-                    <form action="{% url 'search' %}" method="post">
-                        {% csrf_token %}
-                        {{ form|crispy }}
-                        <button type="submit" class="btn btn-primary" name="zillow">Get Zillow Listings</button>
-                    </form>
-                    <hr class="mt-0 mb-2 mt-2">
-                    <h2>Search Craigslist</h2>
-                    <hr class="mt-0 mb-2">
-                    <form action="{% url 'clist_results' %}" method="post">
-                        {% csrf_token %}
-                        <button type="submit" class="btn btn-primary" name="craigslist">Get Craigslist Listings</button>
-                    </form>
-                </div>
             </div>
         </div>
     </div>

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -20,11 +20,13 @@ $(document).ready(function(){
                 <div class="col-5">
                     <h2>Search All Locations</h2>
                     <form action="{% url 'search' %}" method="GET">
-
-                        Zip Code (5 digits): <input type="text" id="zip_code" name="zipcode" minlength="5" maxlength="5"
-                            required pattern="\d*">
-                        <p></p>
-                        <input type="submit" class="btn btn-primary" value="Go">
+                        <div class="input-group">
+                            <input type="text" class="form-control" placeholder="Zip Code (5 digits)" id="zip_code" name="zipcode"
+                                minlength="5" maxlength="5" required pattern="\d*">
+                            <div class="input-group-append">
+                                <input type="submit" class="btn btn-primary" value="Go">
+                            </div>
+                        </div>
                     </form>
                 </div>
             </div>

--- a/search/tests.py
+++ b/search/tests.py
@@ -102,8 +102,9 @@ class SearchIndexViewTests(TestCase):
         """
         response = self.client.get(reverse("search"))
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Get Zillow Listings")
-        self.assertContains(response, "Get Craigslist Listings")
+        self.assertContains(response, "Search All Locations")
+        self.assertContains(response, "Zip Code")
+        self.assertContains(response, "Go")
 
     @mock.patch("search.views.fetch_craigslist_housing", fetch_craigslist_housing)
     def test_search_index_with_zip(self):

--- a/search/views.py
+++ b/search/views.py
@@ -1,13 +1,11 @@
 from django.shortcuts import render
 from django.views import generic
 from django.utils import timezone
-from .forms import ZillowSearchForm
 from .models import CraigslistLocation, LastRetrievedData
 
 
 from external.nyc311 import get_311_data, get_311_statistics
 from external.craigslist import fetch_craigslist_housing
-from external.zillow import get_zillow_housing
 
 
 class CraigslistIndexView(generic.ListView):
@@ -16,17 +14,8 @@ class CraigslistIndexView(generic.ListView):
 
 
 def search(request):
-    if request.method == "POST" and "zillow" in request.POST:
-        # Because we don't have a form for Zillow anymore, temporarily hardcode address and city_state_zip
-        address = "Jay st"
-        city_state_zip = "11201"
-
-        results = get_zillow_housing(
-            address=address, zipcode=city_state_zip, show_rent_z_estimate=True
-        )
-        return render(request, "search/result.html", {"z_results": results})
     # generic zip code form post
-    elif request.method == "GET":
+    if request.method == "GET":
         timeout = False
         zip_code = request.GET.get("zipcode")
         search_data = {}
@@ -57,8 +46,7 @@ def search(request):
         )
     else:
         # render an error
-        form = ZillowSearchForm()
-        return render(request, "search/search.html", {"form": form})
+        return render(request, "search/search.html")
 
 
 def data_311(request):


### PR DESCRIPTION
- removes craigslist button and zillow button from search page
- changes search UI
- redirects a user to the search page when the user has been logged in
- Depends on #156
<img width="469" alt="Screen Shot 2019-10-30 at 2 33 13 PM" src="https://user-images.githubusercontent.com/3467350/67888908-4ebe4e80-fb24-11e9-96fd-a1b56d6cf830.png">

