### PR TITLE
Fix 311 and tests

### DIFF
--- a/cli/get_311_data.py
+++ b/cli/get_311_data.py
@@ -7,9 +7,9 @@ from external.nyc311 import get_311_data  # noqa: E402
 
 if __name__ == "__main__":
     try:
-        zipcode = 10009
+        zipcode = 10000
         print("get_311_data() with valid zipcode", zipcode)
-        query_results = get_311_data(10009, 5)  # valid zip code
+        query_results = get_311_data(zipcode, 5)  # valid zip code
         print(query_results)
         print("No match?", len(query_results) == 0)
     except TimeoutError:

--- a/external/nyc311/sample-response-closed.json
+++ b/external/nyc311/sample-response-closed.json
@@ -1,0 +1,108 @@
+[
+    {
+        "created_date": "2019-11-02T13:38:43.000",
+        "incident_zip": "11361",
+        "incident_address": "45 AVENUE",
+        "complaint_type": "Street Sign - Dangling",
+        "descriptor": "St Name - Attached to Pole",
+        "status": "In Progress"
+    },
+    {
+        "created_date": "2019-11-02T13:38:37.000",
+        "incident_zip": "10016",
+        "incident_address": "201 EAST   28 STREET",
+        "city": "NEW YORK",
+        "complaint_type": "Noise - Helicopter",
+        "descriptor": "Other",
+        "status": "Closed"
+    },
+    {
+        "created_date": "2019-11-02T13:38:21.000",
+        "incident_zip": "10040",
+        "incident_address": "34 HILLSIDE AVENUE",
+        "city": "NEW YORK",
+        "complaint_type": "Noise - Residential",
+        "descriptor": "Loud Music/Party",
+        "status": "Closed"
+    },
+    {
+        "created_date": "2019-11-02T13:38:15.000",
+        "incident_zip": "11201",
+        "incident_address": "8 OLD FULTON STREET",
+        "city": "BROOKLYN",
+        "complaint_type": "Noise - Vehicle",
+        "descriptor": "Car/Truck Music",
+        "status": "Closed"
+    },
+    {
+        "created_date": "2019-11-02T13:38:03.000",
+        "incident_zip": "11415",
+        "incident_address": "110 81 AVENUE",
+        "city": "KEW GARDENS",
+        "complaint_type": "Damaged Tree",
+        "descriptor": "Tree Alive - in Poor Condition",
+        "status": "In Progress"
+    },
+    {
+        "created_date": "2019-11-02T13:38:02.000",
+        "incident_zip": "10000",
+        "incident_address": "CENTRAL PARK",
+        "city": "NEW YORK",
+        "complaint_type": "Noise - Helicopter",
+        "descriptor": "Other",
+        "status": "In Progress"
+    },
+    {
+        "created_date": "2019-11-02T13:38:00.000",
+        "incident_zip": "11377",
+        "incident_address": "50-30 44 STREET",
+        "city": "Woodside",
+        "complaint_type": "Water System",
+        "descriptor": "Hydrant Running (WC3)",
+        "status": "Open"
+    },
+    {
+        "created_date": "2019-11-02T13:38:00.000",
+        "incident_zip": "11216",
+        "incident_address": "311 QUINCY STREET",
+        "city": "BROOKLYN",
+        "complaint_type": "Dirty Conditions",
+        "descriptor": "E3 Dirty Sidewalk",
+        "status": "Open"
+    },
+    {
+        "created_date": "2019-11-02T13:37:57.000",
+        "incident_zip": "11105",
+        "incident_address": "19-19 DITMARS BOULEVARD",
+        "city": "ASTORIA",
+        "complaint_type": "Curb Condition",
+        "descriptor": "Curb Defect-Metal Protruding",
+        "status": "In Progress"
+    },
+    {
+        "created_date": "2019-11-02T13:37:39.000",
+        "incident_zip": "10012",
+        "incident_address": "BOWERY",
+        "complaint_type": "Lost Property",
+        "descriptor": "Bag/Wallet",
+        "status": "Closed"
+    },
+    {
+        "created_date": "2019-11-02T13:37:24.000",
+        "incident_zip": "10009",
+        "incident_address": "405 EAST   14 STREET",
+        "city": "NEW YORK",
+        "complaint_type": "Vending",
+        "descriptor": "Unlicensed",
+        "status": "Closed"
+    },
+    {
+        "created_date": "2019-11-02T13:37:18.000",
+        "incident_zip": "11691",
+        "incident_address": "22-21 EDGEMERE AVENUE",
+        "city": "FAR ROCKAWAY",
+        "complaint_type": "Abandoned Vehicle",
+        "descriptor": "With License Plate",
+        "status": "Closed"
+    }
+]

--- a/external/nyc311/sample-response-single.json
+++ b/external/nyc311/sample-response-single.json
@@ -1,0 +1,11 @@
+[
+    {
+        "created_date": "2019-11-02T13:38:02.000",
+        "incident_zip": "10000",
+        "incident_address": "CENTRAL PARK",
+        "city": "NEW YORK",
+        "complaint_type": "Noise - Helicopter",
+        "descriptor": "Other",
+        "status": "In Progress"
+    }
+]

--- a/external/nyc311/stat.py
+++ b/external/nyc311/stat.py
@@ -67,7 +67,7 @@ def get_311_statistics(
             total_complaints_query_zip = len(complaints_query_zip_df)
             # complaints of the desired type in the zip code of interest that were closed
             closed_complaints_query_zip = len(
-                dict(tuple(complaints_query_zip_df.groupby("status")))["Closed"]
+                dict(tuple(complaints_query_zip_df.groupby("status"))).get("Closed", [])
             )
             percentage_complaints_closed = (
                 closed_complaints_query_zip / total_complaints_query_zip

--- a/external/nyc311/stat.py
+++ b/external/nyc311/stat.py
@@ -44,6 +44,9 @@ def get_311_statistics(
             complaint_type_df_dict[complaint_type]
             for complaint_type in complaint_type_list
         ]
+
+        if not complaint_dfs: continue
+
         complaint_dfs_concatenated = pd.concat(complaint_dfs)
         # The dataframe (which contains only complaints for a specific type e.g. noise)
         # are further grouped by zip code).

--- a/external/nyc311/stat.py
+++ b/external/nyc311/stat.py
@@ -45,7 +45,8 @@ def get_311_statistics(
             for complaint_type in complaint_type_list
         ]
 
-        if not complaint_dfs: continue
+        if not complaint_dfs:
+            continue
 
         complaint_dfs_concatenated = pd.concat(complaint_dfs)
         # The dataframe (which contains only complaints for a specific type e.g. noise)

--- a/external/nyc311/stub.py
+++ b/external/nyc311/stub.py
@@ -18,6 +18,7 @@ def fetch_311_data_closed(
     with open(filepath) as f:
         return json.loads(f.read())
 
+
 def fetch_311_data_single(
     zip, max_query_results=None, num_entries_to_search=10000, t_out=10
 ) -> Dict[str, any]:

--- a/external/nyc311/stub.py
+++ b/external/nyc311/stub.py
@@ -9,3 +9,18 @@ def fetch_311_data(
     filepath = os.path.join(os.path.dirname(__file__), "sample-response.json")
     with open(filepath) as f:
         return json.loads(f.read())
+
+
+def fetch_311_data_closed(
+    zip, max_query_results=None, num_entries_to_search=10000, t_out=10
+) -> Dict[str, any]:
+    filepath = os.path.join(os.path.dirname(__file__), "sample-response-closed.json")
+    with open(filepath) as f:
+        return json.loads(f.read())
+
+def fetch_311_data_single(
+    zip, max_query_results=None, num_entries_to_search=10000, t_out=10
+) -> Dict[str, any]:
+    filepath = os.path.join(os.path.dirname(__file__), "sample-response-single.json")
+    with open(filepath) as f:
+        return json.loads(f.read())

--- a/external/nyc311/tests.py
+++ b/external/nyc311/tests.py
@@ -5,6 +5,7 @@ import pandas as pd
 from .stat import get_311_statistics
 from .fetch import fetch_311_data, fetch_311_data_as_dataframe, get_311_data
 from .stub import fetch_311_data as fetch_311_data_stub
+from .stub import fetch_311_data_closed as fetch_311_data_closed_stub
 from .models import NYC311Statistics, NYC311Complaint
 
 
@@ -29,8 +30,8 @@ class FetchNYC311ConstraintsTests(TestCase):
         client.get.assert_called_once()
 
 
-@mock.patch("external.nyc311.fetch.fetch_311_data", fetch_311_data_stub)
 class NYC311StatiscticsTests(TestCase):
+    @mock.patch("external.nyc311.fetch.fetch_311_data", fetch_311_data_stub)
     def test_statistics_returns(self):
         try:
             stats = get_311_statistics("11201")
@@ -39,6 +40,16 @@ class NYC311StatiscticsTests(TestCase):
         except TimeoutError:
             pass
 
+    @mock.patch("external.nyc311.fetch.fetch_311_data", fetch_311_data_closed_stub)
+    def test_statistics_returns_with_closed(self):
+        try:
+            stats = get_311_statistics("11201")
+            for s in stats:
+                self.assertTrue(isinstance(s, NYC311Statistics))
+        except TimeoutError:
+            pass
+
+    @mock.patch("external.nyc311.fetch.fetch_311_data", fetch_311_data_stub)
     def test_statistics_value(self):
         """
         tests excact value of the returned statistics by comparing them to

--- a/search/tests.py
+++ b/search/tests.py
@@ -6,6 +6,7 @@ from unittest import mock
 import datetime
 from .models import CraigslistLocation, LastRetrievedData
 from external.craigslist.stub import fetch_craigslist_housing
+from external.nyc311.stub import fetch_311_data
 
 
 def create_c_location(
@@ -107,6 +108,7 @@ class SearchIndexViewTests(TestCase):
         self.assertContains(response, "Go")
 
     @mock.patch("search.views.fetch_craigslist_housing", fetch_craigslist_housing)
+    @mock.patch("external.nyc311.fetch.fetch_311_data", fetch_311_data)
     def test_search_index_with_zip(self):
         """
         Tests the search page being retrieved with a zip code
@@ -116,6 +118,7 @@ class SearchIndexViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Zip Code:")
 
+    @mock.patch("external.nyc311.fetch.fetch_311_data", fetch_311_data)
     def test_search_index_no_zip(self):
         """
         tests the search page with an incomplete zip passed in


### PR DESCRIPTION
- Some of our tests is making a request to nyc open data, which is supposed to be patched
- Apparently 311 stat doesn't work for some input data
- Our test results was inconsistent because it depends on live 311 data