### PR TITLE
removed deprecated self.url call from __str__ method on Apartment model

### DIFF
--- a/location/models.py
+++ b/location/models.py
@@ -45,7 +45,7 @@ class Apartment(models.Model):
     zillow_url = models.URLField()
 
     def __str__(self):
-        return f"Apartment({self.suite_num}, {self.url}) - {self.location.address}"
+        return f"Apartment({self.suite_num}) - {self.location.address}"
 
     @property
     def estimated_rent_price_for_display(self):


### PR DESCRIPTION
Fixed a minor issue that I missed in my code review where the presence of self.url in  the Apartment __str__ method causes the admin dashboard to crash since .url was updated to zillow.url.