### PR TITLE
Search Locations based on Min/Max Price

### DIFF
--- a/search/forms.py
+++ b/search/forms.py
@@ -1,1 +1,64 @@
-# from django import forms
+from django import forms
+from django.core import validators
+from crispy_forms.helper import FormHelper
+from crispy_forms.layout import Layout, Submit, Field
+
+
+class SearchForm(forms.Form):
+    zipcode = forms.CharField(
+        max_length=5,
+        min_length=5,
+        required=True,
+        validators=[
+            validators.RegexValidator(
+                regex="^\d*$", message="Please use numbers"
+            )  # noqa : W605
+        ],
+    )
+    min_price = forms.IntegerField(min_value=0, required=False)
+    max_price = forms.IntegerField(min_value=0, required=False)
+
+    def __init__(self, *args, **kwargs):
+        self.helper = FormHelper()
+
+        self.helper.form_method = "get"
+        self.helper.form_action = "search"
+        # add css classes to the form
+        self.helper.form_class = "form-inline"
+        self.helper.error_text_inline = True
+        # adds css class to the labels
+        self.helper.label_class = "sr-only"
+        self.helper.field_template = "bootstrap4/layout/inline_field.html"
+        self.helper.layout = Layout(
+            Field(
+                "zipcode",
+                css_class="form-control-sm mb-2 mr-sm-2",
+                placeholder="Zip Code",
+            ),
+            Field(
+                "min_price",
+                css_class="form-control-sm mb-2 mr-sm-2",
+                placeholder="Min Price",
+            ),
+            Field(
+                "max_price",
+                css_class="form-control-sm mb-2 mr-sm-2",
+                placeholder="Max Price",
+            ),
+            Submit("search", "Go", css_class="btn btn-primary mb-2"),
+        )
+        super(SearchForm, self).__init__(*args, **kwargs)
+
+    def clean(self):
+        super(SearchForm, self).clean()
+
+        min_price = self.cleaned_data.get("min_price")
+        max_price = self.cleaned_data.get("max_price")
+
+        if min_price and max_price:
+            if min_price > max_price:
+                # adds error messages just to the fields
+                # if we raise a Validation error the layout of the inline-form
+                # is messed up
+                self.add_error("min_price", "Larger than Max")
+                self.add_error("max_price", "Less than Min")

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -4,11 +4,11 @@
 
 {%  block script %}
 <script>
-$(document).ready(function(){
-  $("#complaints_button").click(function(){
-    $("#complaints").toggle();
-  });
-});
+    $(document).ready(function () {
+        $("#complaints_button").click(function () {
+            $("#complaints").toggle();
+        });
+    });
 </script>
 
 <style>
@@ -26,10 +26,10 @@ $(document).ready(function(){
     border-style: solid;
 }
 
-div.meter {
-    display: inline-block;
-    vertical-align: middle;
-}
+    div.meter {
+        display: inline-block;
+        vertical-align: middle;
+    }
 
 .meter > span {
   display: block;
@@ -70,16 +70,22 @@ div.meter {
     <div class="row justify-content-center h-30">
         <div class="col-12">
             <div class="row">
-                <div class="col-5">
+                <div class="col">
                     <h2>Search All Locations</h2>
-                    <form action="{% url 'search' %}" method="GET">
-                        <div class="input-group">
-                            <input type="text" class="form-control" placeholder="Zip Code (5 digits)" id="zip_code" name="zipcode"
-                                minlength="5" maxlength="5" required pattern="\d*">
-                            <div class="input-group-append">
-                                <input type="submit" class="btn btn-primary" value="Go">
-                            </div>
-                        </div>
+                    <form action="{% url 'search' %}" method="GET" class="form-inline">
+                        <label class="sr-only" for="zip_code">Zipcode</label>
+                        <input type="text" class="form-control mb-2 mr-sm-2" placeholder="Zip Code (5 digits)"
+                                        id="zip_code" name="zipcode" minlength="5" maxlength="5" pattern="\d*" required>
+                        
+                        <label class="sr-only" for="min_price">Min Price</label>
+                        <input type="number" class="form-control mb-2 mr-sm-2" placeholder="Min Price" id="min_price"
+                                        name="min_price">
+                        
+                        <label class="sr-only" for="max_price">Max Price</label>
+                        <input type="number" class="form-control mb-2 mr-sm-2" placeholder="Max Price" id="max_price"
+                                        name="max_price">
+                        
+                        <input type="submit" class="btn btn-primary mb-2" value="Go">
                     </form>
                 </div>
             </div>
@@ -87,7 +93,8 @@ div.meter {
     </div>
     <br>
     <div>
-        <h3>Search results for {{ zip }}</h3>
+        <h3>Search results</h3>
+        <p>{{ search_title }}</p>
     </div>
     {% if search_data.stats %}
     <p>
@@ -98,11 +105,12 @@ div.meter {
             {{ search_data.description_for_complaint_level }}
         </span>
         <ul id="stats-list" class="horizontal-list" stype="display: inline-block">
-        {% for key, percentage in search_data.stats %}
+            {% for key, percentage in search_data.stats %}
             <li>
-                <span>{{ key }} </span><div class="meter"><span style="width: {{ percentage }}%"></span></div>
+                <span>{{ key }} </span>
+                <div class="meter"><span style="width: {{ percentage }}%"></span></div>
             </li>
-        {% endfor %}
+            {% endfor %}
         </ul>
         <a href="{% url 'data_311'%}?zip_code={{zip}}">See more</a>
         </div>
@@ -125,7 +133,7 @@ div.meter {
             </div>
         </div>
         {% else %}
-            No locations
+        No locations
         {% endif %}
     </div>
 

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -107,8 +107,7 @@
         <ul id="stats-list" class="horizontal-list" stype="display: inline-block">
             {% for key, percentage in search_data.stats %}
             <li>
-                <span>{{ key }} </span>
-                <div class="meter"><span style="width: {{ percentage }}%"></span></div>
+                <span>{{ key }} </span><div class="meter"><span style="width: {{ percentage }}%"></span></div>
             </li>
             {% endfor %}
         </ul>

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -72,21 +72,7 @@
             <div class="row">
                 <div class="col">
                     <h2>Search All Locations</h2>
-                    <form action="{% url 'search' %}" method="GET" class="form-inline">
-                        <label class="sr-only" for="zip_code">Zipcode</label>
-                        <input type="text" class="form-control mb-2 mr-sm-2" placeholder="Zip Code (5 digits)"
-                                        id="zip_code" name="zipcode" minlength="5" maxlength="5" pattern="\d*" required>
-                        
-                        <label class="sr-only" for="min_price">Min Price</label>
-                        <input type="number" class="form-control mb-2 mr-sm-2" placeholder="Min Price" id="min_price"
-                                        name="min_price">
-                        
-                        <label class="sr-only" for="max_price">Max Price</label>
-                        <input type="number" class="form-control mb-2 mr-sm-2" placeholder="Max Price" id="max_price"
-                                        name="max_price">
-                        
-                        <input type="submit" class="btn btn-primary mb-2" value="Go">
-                    </form>
+                    {% crispy search_form %}
                 </div>
             </div>
         </div>

--- a/search/tests.py
+++ b/search/tests.py
@@ -126,8 +126,51 @@ class SearchIndexViewTests(TestCase):
         """
         response = self.client.get("/search/?zipcode=")
         self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, "Zip Code:")
+        self.assertNotContains(response, "Zipcode:")
+    
+    @mock.patch("search.views.fetch_craigslist_housing", fetch_craigslist_housing)
+    @mock.patch("external.nyc311.fetch.fetch_311_data", fetch_311_data)
+    def test_search_page_zip_only(self):
+        """
+        tests the search page with only a zipcode passed in
+        """
+        response = self.client.get("/search/?zipcode=10000")
+        self.assertContains(response, "Zipcode: 10000")
+        self.assertNotContains(response, "Max Price:")
+        self.assertNotContains(response, "Min Price:")
 
+    @mock.patch("search.views.fetch_craigslist_housing", fetch_craigslist_housing)
+    @mock.patch("external.nyc311.fetch.fetch_311_data", fetch_311_data)
+    def test_search_page_min_price(self):
+        """
+        tests the search page with only a zipcode passed in
+        """
+        response = self.client.get("/search/?zipcode=10000&min_price=500")
+        self.assertContains(response, "Zipcode: 10000")
+        self.assertNotContains(response, "Max Price:")
+        self.assertContains(response, "Min Price: 500")
+
+    @mock.patch("search.views.fetch_craigslist_housing", fetch_craigslist_housing)
+    @mock.patch("external.nyc311.fetch.fetch_311_data", fetch_311_data)
+    def test_search_page_max_price(self):
+        """
+        tests the search page with only a zipcode passed in
+        """
+        response = self.client.get("/search/?zipcode=10000&min_price=&max_price=2000")
+        self.assertContains(response, "Zipcode: 10000")
+        self.assertContains(response, "Max Price: 2000")
+        self.assertNotContains(response, "Min Price:")
+    
+    @mock.patch("search.views.fetch_craigslist_housing", fetch_craigslist_housing)
+    @mock.patch("external.nyc311.fetch.fetch_311_data", fetch_311_data)
+    def test_search_page_all_params(self):
+        """
+        tests the search page with only a zipcode passed in
+        """
+        response = self.client.get("/search/?zipcode=10000&min_price=500&max_price=2000")
+        self.assertContains(response, "Zipcode: 10000")
+        self.assertContains(response, "Max Price: 2000")
+        self.assertContains(response, "Min Price: 500")
 
 class SearchCraigsTests(TestCase):
     @mock.patch("search.views.fetch_craigslist_housing", fetch_craigslist_housing)
@@ -138,3 +181,4 @@ class SearchCraigsTests(TestCase):
         pass
         response = self.client.get(reverse("clist_results"))
         self.assertEqual(response.status_code, 200)
+    

--- a/search/tests.py
+++ b/search/tests.py
@@ -127,7 +127,7 @@ class SearchIndexViewTests(TestCase):
         response = self.client.get("/search/?zipcode=")
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, "Zipcode:")
-    
+
     @mock.patch("search.views.fetch_craigslist_housing", fetch_craigslist_housing)
     @mock.patch("external.nyc311.fetch.fetch_311_data", fetch_311_data)
     def test_search_page_zip_only(self):
@@ -160,17 +160,20 @@ class SearchIndexViewTests(TestCase):
         self.assertContains(response, "Zipcode: 10000")
         self.assertContains(response, "Max Price: 2000")
         self.assertNotContains(response, "Min Price:")
-    
+
     @mock.patch("search.views.fetch_craigslist_housing", fetch_craigslist_housing)
     @mock.patch("external.nyc311.fetch.fetch_311_data", fetch_311_data)
     def test_search_page_all_params(self):
         """
         tests the search page with only a zipcode passed in
         """
-        response = self.client.get("/search/?zipcode=10000&min_price=500&max_price=2000")
+        response = self.client.get(
+            "/search/?zipcode=10000&min_price=500&max_price=2000"
+        )
         self.assertContains(response, "Zipcode: 10000")
         self.assertContains(response, "Max Price: 2000")
         self.assertContains(response, "Min Price: 500")
+
 
 class SearchCraigsTests(TestCase):
     @mock.patch("search.views.fetch_craigslist_housing", fetch_craigslist_housing)
@@ -181,4 +184,3 @@ class SearchCraigsTests(TestCase):
         pass
         response = self.client.get(reverse("clist_results"))
         self.assertEqual(response.status_code, 200)
-    

--- a/search/tests.py
+++ b/search/tests.py
@@ -116,7 +116,8 @@ class SearchIndexViewTests(TestCase):
         """
         response = self.client.get("/search/?zipcode=10000")
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Search results for 10000")
+        self.assertContains(response, "Search results")
+        self.assertContains(response, "Zipcode: 10000")
 
     @mock.patch("external.nyc311.fetch.fetch_311_data", fetch_311_data)
     def test_search_index_no_zip(self):

--- a/search/views.py
+++ b/search/views.py
@@ -30,6 +30,8 @@ def search(request):
         if max_price:
             search_title = search_title + f"Max Price: {max_price} "
 
+        # build the query parameter dictionary that will be used to
+        # query the Location model
         query_params = build_search_query(
             zip_code=zip_code, max_price=max_price, min_price=min_price
         )
@@ -170,7 +172,7 @@ def css_color_for_complaint_level(level):
     colors = ["lightgreen", "lightgreen", "orange", "orange", "orangered", "orangered"]
     return colors[level]
 
-    
+
 def build_search_query(zip_code, min_price, max_price):
     # builds a dictionary of query parameters used to pass values into
     # the Location model query


### PR DESCRIPTION
This PR adds the functionality to (optionally) specify the min/max price for an apartment.  The zip code is still mandatory for now, but you can specify a min or max or both prices.

Also adds some functionality to optionally pass in search parameters to the `Location.objects.filter(...)` function so searches can easily be updated depending on the search terms.