### PR TITLE
Apartment detail view

### DIFF
--- a/citystreets/urls.py
+++ b/citystreets/urls.py
@@ -27,5 +27,4 @@ urlpatterns = [
     path("location/", include("location.urls")),
 ]
 
-if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/citystreets/urls.py
+++ b/citystreets/urls.py
@@ -15,6 +15,8 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
+from django.conf import settings
+from django.conf.urls.static import static
 
 
 urlpatterns = [
@@ -24,3 +26,6 @@ urlpatterns = [
     path("map/", include("map.urls")),
     path("location/", include("location.urls")),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/location/templates/apartment.html
+++ b/location/templates/apartment.html
@@ -1,0 +1,60 @@
+{% extends 'base.html' %}
+
+{% block script %}
+<link href="https://cdnjs.cloudflare.com/ajax/libs/mdbootstrap/4.1.1/css/mdb.min.css" rel="stylesheet">
+{% endblock %}
+
+{% block content %}
+  <!--Main layout-->
+  <main class="mt-5 pt-4">
+    <div class="container dark-grey-text mt-5">
+
+      <!--Grid row-->
+      <div class="row wow fadeIn">
+
+        <!--Grid column-->
+        <div class="col-md-6 mb-4">
+
+            {% if apt.image %}
+                <img src="{{ apt.image.url }} " class="img-fluid" alt="apartment image">
+            {% endif %}
+
+        </div>
+        <!--Grid column-->
+
+        <!--Grid column-->
+        <div class="col-md-6 mb-4">
+
+          <!--Content-->
+          <div class="p-4">
+            <p class="lead font-weight-bold">{{loc.address}}, {{loc.city}}, {{loc.state}}, {{loc.zipcode}}</p>
+
+
+
+            <p class="lead">
+              <span>{{ apt.rent_price_for_display }}</span>
+            </p>
+
+
+
+            <form class="d-flex justify-content-left">
+              <button class="btn btn-primary btn-md my-0 p" type="submit">Apply!</button>
+
+            </form>
+
+          </div>
+          <!--Content-->
+
+        </div>
+        <!--Grid column-->
+
+      </div>
+      <!--Grid row-->
+
+      <hr>
+
+    </div>
+
+  </main>
+
+{% endblock %}

--- a/location/templates/apartment.html
+++ b/location/templates/apartment.html
@@ -35,7 +35,10 @@
               <span>{{ apt.rent_price_for_display }}</span>
             </p>
 
-
+            <p>(Default Description) Bright one bedroom apartment in the heart of Bay Ridge. Located in the 80's near 3rd Avenue the property
+                is steps to shopping and restaurants and a short walk to the R train 86th Street station.
+                The apartment is in a walk-up building. It features an eat-in kitchen, hardwood floors and freshly
+                painted rooms. Good credit and proof of income are needed.</p>
 
             <form class="d-flex justify-content-left">
               <button class="btn btn-primary btn-md my-0 p" type="submit">Apply!</button>

--- a/location/templates/apartment.html
+++ b/location/templates/apartment.html
@@ -29,7 +29,10 @@
           <div class="p-4">
             <p class="lead font-weight-bold">{{loc.address}}, {{loc.city}}, {{loc.state}}, {{loc.zipcode}}</p>
 
-
+            <div class="mb-3">
+                <span class="badge red mr-1">Suite: {{ apt.suite_num }}</span>
+                <span class="badge blue mr-1">Bedrooms: {{ apt.number_of_bed }}</span>
+            </div>
 
             <p class="lead">
               <span>{{ apt.rent_price_for_display }}</span>

--- a/location/templates/location.html
+++ b/location/templates/location.html
@@ -46,14 +46,12 @@
             <ul>
             {% for apt in zillow_list %}
             <li>
-              <a href={{apt.zillow_url}}>
               <h3>
                 {% if apt.suite_num %}
-                  <span class="badge badge-secondary">#{{apt.suite_num}}</span>
+                    <a href={{apt.zillow_url}}><span class="badge badge-secondary">#{{apt.suite_num}}</span></a>
                 {% endif %}
                 {{apt.rent_price_for_display}}
               </h3>
-              </a>
             </li>
             {% endfor %}
             </ul>

--- a/location/templates/location.html
+++ b/location/templates/location.html
@@ -64,7 +64,7 @@
             <li>
               <h3>
                 {% if apt.suite_num %}
-                  <span class="badge badge-secondary">#{{apt.suite_num}}</span>
+                    <a href="{% url 'apartment' pk=object.id suite_num=apt.suite_num %}"><span class="badge badge-secondary">#{{apt.suite_num}}</span></a>
                 {% endif %}
                 {{apt.rent_price_for_display}}
               </h3>

--- a/location/templates/location.html
+++ b/location/templates/location.html
@@ -48,9 +48,10 @@
             <li>
               <h3>
                 {% if apt.suite_num %}
-                    <a href={{apt.zillow_url}}><span class="badge badge-secondary">#{{apt.suite_num}}</span></a>
+                    <a href="{% url 'apartment' pk=object.id suite_num=apt.suite_num %}"><span class="badge badge-secondary">#{{apt.suite_num}}</span></a>
                 {% endif %}
                 {{apt.rent_price_for_display}}
+                <a href="{{ apt.zillow_url }}"><span class="badge badge-secondary">Zillow</span></a>
               </h3>
             </li>
             {% endfor %}

--- a/location/tests.py
+++ b/location/tests.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.urls import reverse
 from datetime import datetime
-from .models import Location
+from .models import Location, Apartment
 from mainapp.models import SiteUser
 from review.models import Review
 import string
@@ -79,3 +79,33 @@ class LocationViewTests(TestCase):
         )
         response = self.client.get(reverse("location", args=(1,)))
         self.assertContains(response, "Write something")
+
+    def test_apartment_view(self):
+        """create location and apartment associated with that location.
+        test checks if the apartment detail view is loaded"""
+        city = "Brooklyn"
+        state = "New York"
+        address = "1234 Coney Island Avenue"
+        zipcode = 11218
+        # using get_or_create avoids race condition
+        loc = Location.objects.get_or_create(
+            city=city, state=state, address=address, zipcode=zipcode
+        )[0]
+
+        # create an apartment and link it to that location
+        suite_num = "18C"
+        number_of_bed = 3
+        image = "Images/System_Data_Flow_Diagram.png"
+        rent_price = 3000
+        apt = Apartment.objects.create(
+            suite_num=suite_num,
+            number_of_bed=number_of_bed,
+            image=image,
+            rent_price=rent_price,
+            location=loc,
+        )
+
+        response = self.client.get(
+            reverse("apartment", kwargs={"pk": loc.id, "suite_num": apt.suite_num})
+        )
+        self.assertEqual(response.status_code, 200)

--- a/location/urls.py
+++ b/location/urls.py
@@ -4,7 +4,9 @@ from . import views
 
 urlpatterns = [
     path("<int:pk>/", views.LocationView.as_view(), name="location"),
-    path("<int:pk>/apartment/<suite_num>", views.apartment_detail_view, name="apartment"),
+    path(
+        "<int:pk>/apartment/<suite_num>", views.apartment_detail_view, name="apartment"
+    ),
     path("<int:pk>/favorite", views.favorites, name="favorite"),
     path("favlist", views.favlist, name="favlist"),
     path("<int:pk>/review", views.review, name="review"),

--- a/location/urls.py
+++ b/location/urls.py
@@ -4,6 +4,7 @@ from . import views
 
 urlpatterns = [
     path("<int:pk>/", views.LocationView.as_view(), name="location"),
+    path("<int:pk>/apartment/<suite_num>", views.apartment_detail_view, name="apartment"),
     path("<int:pk>/favorite", views.favorites, name="favorite"),
     path("favlist", views.favlist, name="favlist"),
     path("<int:pk>/review", views.review, name="review"),

--- a/location/views.py
+++ b/location/views.py
@@ -30,6 +30,13 @@ class LocationView(generic.DetailView):
         context["landlord_list"] = self.object.apartment_set.filter(zpid=None).all()
         return context
 
+def apartment_detail_view(request, pk, suite_num):
+    loc = Location.objects.get(pk=pk)
+    apt = loc.apartment_set.get(suite_num=suite_num)
+
+    return render(
+        request, "apartment.html", {"loc": loc, "apt": apt}
+    )
 
 @login_required
 def favorites(request, pk):

--- a/location/views.py
+++ b/location/views.py
@@ -30,13 +30,13 @@ class LocationView(generic.DetailView):
         context["landlord_list"] = self.object.apartment_set.filter(zpid=None).all()
         return context
 
+
 def apartment_detail_view(request, pk, suite_num):
     loc = Location.objects.get(pk=pk)
     apt = loc.apartment_set.get(suite_num=suite_num)
 
-    return render(
-        request, "apartment.html", {"loc": loc, "apt": apt}
-    )
+    return render(request, "apartment.html", {"loc": loc, "apt": apt})
+
 
 @login_required
 def favorites(request, pk):


### PR DESCRIPTION
This PR closes #196 
- Creates apartment detail view
- Links it from the location detail view
- For apartments that are from zillow, Zillow badge is displayed that links to zillow page for the apartment
- For all apartments (zillow and landlord) suite number badge directs to the apartment detail view
- Apartment detail view has these features for now:
1. Default Description
2. Image (if available)
3. Badges for suite number and number of bedrooms
- TODO in the future:
1. By clicking on the apply button, a popup appears displaying a textbox that can be used to send a message to the landlord
2. Display apartment reviews and "write review" functionalities below the apartment description.