### PR TITLE
Feature/geo upload

### DIFF
--- a/external/googleapi/g_utils.py
+++ b/external/googleapi/g_utils.py
@@ -1,0 +1,13 @@
+def parse_lat_lng(geo_result_obj):
+    """
+    Parses out a latitude/longitude tuple from the Google Geocoder response object
+    """
+    if geo_result_obj:
+        if "geometry" in geo_result_obj.keys():
+            geo = geo_result_obj["geometry"]
+            if "location" in geo.keys():
+                location = geo_result_obj["geometry"]["location"]
+                return (location["lat"], location["lng"])
+
+    # default case if there was no result returned
+    return (None, None)

--- a/external/googleapi/tests.py
+++ b/external/googleapi/tests.py
@@ -3,6 +3,7 @@ from unittest import mock
 import attr
 
 from .fetch import fetch_geocode, fetch_reverse_geocode
+from .g_utils import parse_lat_lng
 from .stub import fetch_geocode as fetch_geocode_stub
 from .stub import fetch_reverse_geocode as fetch_reverse_geocode_stub
 from .stub import fetch_geocode_no_zip, fetch_reverse_geocode_no_zip
@@ -420,3 +421,38 @@ class GeocodeTests(TestCase):
             GeocodeResponse(**results[0]),
             GeocodeResponse.from_any(precomputed_response),
         )
+
+
+class GUtilsTests(TestCase):
+    def test_parse_lat_lng_empty_param(self):
+        """
+        Tests the parse_lat_lng function with an empty
+        parameter
+        """
+        resp = parse_lat_lng(None)
+        self.assertTupleEqual(resp, (None, None), msg="Failed to return an empty tuple")
+
+    def test_parse_lat_lng_valid(self):
+        """
+        Tests the parse_lat_lng function with valid input
+        """
+        input = fetch_geocode_stub("1234")
+        valid_resp = (40.763374, -73.910995)
+        test = parse_lat_lng(input[0])
+        self.assertTupleEqual(test, valid_resp, msg="Failed to parse a valid response")
+
+    def test_parse_lat_lng_malformed(self):
+        """
+        tests the parse_lat_lng function with a malformed response object
+        """
+        malformed_response = {"geometry": {"lat": 40.763374, "lng": -73.910995}}
+
+        self.assertTupleEqual(parse_lat_lng(malformed_response), (None, None))
+
+    def test_parse_lat_lng_invalid_input(self):
+        """
+        tests the parse_lat_lng function with an incorrect input
+        """
+        input = fetch_geocode_stub("1234")
+        with self.assertRaises(AttributeError):
+            parse_lat_lng(input)

--- a/location/tests.py
+++ b/location/tests.py
@@ -1,14 +1,10 @@
 from django.test import TestCase
 from django.urls import reverse
-<<<<<<< HEAD
-=======
 from django.core.files.uploadedfile import InMemoryUploadedFile
 
 from PIL import Image
 from io import BytesIO
 
-from datetime import datetime
->>>>>>> added utility methods, api call, and tests
 from .models import Location, Apartment
 from mainapp.models import SiteUser
 from review.models import Review
@@ -132,6 +128,58 @@ class LocationViewTests(TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_location_upload_not_logged_in(self):
+        """
+        tests a GET response against the apartment_upload page
+        while not logged in
+        """
+        response = self.client.get(reverse("apartment_upload"))
+        self.assertRedirects(
+            response, "/accounts/login/?next=/location/apartment_upload"
+        )
+
+    def test_location_upload_logged_in(self):
+        """
+        tests a GET requests against the apartment_upload page while
+        logged in
+        """
+        self.client.force_login(SiteUser.objects.create(username="testuser"))
+        response = self.client.get(reverse("apartment_upload"))
+        self.assertEqual(response.status_code, 200)
+
+    @mock.patch("external.googleapi.fetch.googlemaps.Client")
+    def test_location_upload_post(self, mock_client):
+        """
+        tests a POST against the apartment_upload page while
+        logged in as a landlord
+        """
+        mock_client().geocode = mock.MagicMock(return_value=fetch_geocode_stub("11103"))
+
+        self.client.force_login(SiteUser.objects.create(username="testuser"))
+
+        # Create a fake image
+        im = Image.new(mode="RGB", size=(200, 200))
+        im_io = BytesIO()
+        im.save(im_io, "JPEG")
+        im_io.seek(0)
+        mem_image = InMemoryUploadedFile(
+            im_io, None, "image.jpg", "image/jpeg", len(im_io.getvalue()), None
+        )
+
+        post_data = {
+            "city": "New York",
+            "state": "NY",
+            "address": "111 anytown st",
+            "zipcode": "10003",
+            "suite_num": "1",
+            "rent_price": 2500,
+            "number_of_bed": 1,
+            "image": mem_image,
+        }
+
+        response = self.client.post(reverse("apartment_upload"), post_data)
+        self.assertRedirects(response, reverse("apartment_upload_confirmation"))
+
 
 class ClaimViewTests(TestCase):
     fixtures = ["locations.json"]
@@ -230,58 +278,3 @@ class ClaimViewTests(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "successful")
-    def test_location_upload_not_logged_in(self):
-        """
-        tests a GET response against the apartment_upload page
-        while not logged in
-        """
-        response = self.client.get(reverse("apartment_upload"))
-        self.assertRedirects(
-            response, "/accounts/login/?next=/location/apartment_upload"
-        )
-
-    def test_location_upload_logged_in(self):
-        """
-        tests a GET requests against the apartment_upload page while
-        logged in
-        """
-        self.client.force_login(
-            SiteUser.objects.create(user_type="L", username="testuser")
-        )
-        response = self.client.get(reverse("apartment_upload"))
-        self.assertEqual(response.status_code, 200)
-
-    @mock.patch("external.googleapi.fetch.googlemaps.Client")
-    def test_location_upload_post(self, mock_client):
-        """
-        tests a POST against the apartment_upload page while
-        logged in as a landlord
-        """
-        mock_client().geocode = mock.MagicMock(return_value=fetch_geocode_stub("11103"))
-
-        self.client.force_login(
-            SiteUser.objects.create(user_type="L", username="testuser")
-        )
-
-        # Create a fake image
-        im = Image.new(mode="RGB", size=(200, 200))
-        im_io = BytesIO()
-        im.save(im_io, "JPEG")
-        im_io.seek(0)
-        mem_image = InMemoryUploadedFile(
-            im_io, None, "image.jpg", "image/jpeg", len(im_io.getvalue()), None
-        )
-
-        post_data = {
-            "city": "New York",
-            "state": "NY",
-            "address": "111 anytown st",
-            "zipcode": "10003",
-            "suite_num": "1",
-            "rent_price": 2500,
-            "number_of_bed": 1,
-            "image": mem_image,
-        }
-
-        response = self.client.post(reverse("apartment_upload"), post_data)
-        self.assertRedirects(response, reverse("apartment_upload_confirmation"))

--- a/location/tests.py
+++ b/location/tests.py
@@ -55,6 +55,9 @@ class LocationModelTests(TestCase):
         self.assertEqual(l1.avg_rate(), 0)
 
 
+@mock.patch(
+    "external.googleapi.fetch.get_google_api_key", mock.MagicMock(return_value="1111")
+)
 @mock.patch("external.zillow.fetch.fetch_zillow_housing", fetch_zillow_housing)
 class LocationViewTests(TestCase):
     fixtures = ["locations.json"]

--- a/location/views.py
+++ b/location/views.py
@@ -131,8 +131,10 @@ def apartment_upload(request):
             suite_num = form.cleaned_data["suite_num"]
             number_of_bed = form.cleaned_data["number_of_bed"]
 
+            # retrieve the geocoded data from google
             g_data = fetch_geocode(f"{address}, {city} {state}, {zipcode}")
 
+            # parse out the latitude and longitude from the response
             lat_lng = g_utils.parse_lat_lng(g_data[0])
 
             # create or retrieve an existing location
@@ -141,6 +143,16 @@ def apartment_upload(request):
             )  # using get_or_create avoids race condition
 
             if created:
+                # we add the location here instead of in the get_or_create method
+                # due to multiple locations being created from the same address
+                # this was happening due to the lat/lng returned from the API sometimes
+                # had more digits than what we stored in the DB
+                loc.latitude = lat_lng[0]
+                loc.longitude = lat_lng[1]
+                loc.save()
+            elif loc.latitude is None and loc.longitude is None:
+                # if the location exists but doesn't have lat/lng values
+                # add them
                 loc.latitude = lat_lng[0]
                 loc.longitude = lat_lng[1]
                 loc.save()
@@ -156,7 +168,7 @@ def apartment_upload(request):
 
             apt.save()
 
-            # redirect to a new URL:
+            # redirect to the confirmation page
             return HttpResponseRedirect(reverse("apartment_upload_confirmation"))
 
     # if a GET (or any other method) we'll create a blank form

--- a/location/views.py
+++ b/location/views.py
@@ -120,7 +120,7 @@ def apartment_upload(request):
         form = ApartmentUploadForm(request.POST, request.FILES)
         # check whether it's valid:
         if form.is_valid():
-            print("is valid")
+
             # process the data in form.cleaned_data as required
             city = form.cleaned_data["city"]
             state = form.cleaned_data["state"]
@@ -158,8 +158,7 @@ def apartment_upload(request):
 
             # redirect to a new URL:
             return HttpResponseRedirect(reverse("apartment_upload_confirmation"))
-        else:
-            print("not valid")
+
     # if a GET (or any other method) we'll create a blank form
     else:
         form = ApartmentUploadForm()


### PR DESCRIPTION
This PR includes the geocoder API ability when someone uploads an apartment.

Currently all it does is use the address string -- {address}, {city} {state}, {zip} -- to call the geocoder api and add lat/lon of the first returned result to the location record. You can tell that the lat/lon has been added by an actual pin on the map in the location view for user-uploaded locations.

This also ups our test coverage.