### PR TITLE
Fix a bug on search

### DIFF
--- a/search/views.py
+++ b/search/views.py
@@ -196,9 +196,12 @@ def build_search_query(address, min_price, max_price, bed_num):
     query_params = {}
     if address:
         # filter based on existence of locations with the specified address
-        query_params["city"] = address.city
-        query_params["state"] = address.state
-        query_params["zipcode"] = address.zipcode
+        if address.city:
+            query_params["city"] = address.city
+        if address.state:
+            query_params["state"] = address.state
+        if address.zipcode:
+            query_params["zipcode"] = address.zipcode
     if max_price:
         # filter based on existence of apartments  with a rent_price less than or equal (lte)
         # than the max_price


### PR DESCRIPTION
If you search "brooklyn", every location in the brooklyn should be shown up
Now we give zipcode as empty string in some cases so that it filters locations by the empty zipcode, which results empty search results.