### PR TITLE
Deleting an Apartment

### DIFF
--- a/location/forms.py
+++ b/location/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.core.validators import MinValueValidator
 from crispy_forms.helper import FormHelper
-from crispy_forms.layout import Layout, Submit, Button, ButtonHolder
+from crispy_forms.layout import Layout, Submit, Button, ButtonHolder, Div
 
 from localflavor.us import forms as us_forms
 from .models import Location, Apartment
@@ -89,12 +89,37 @@ class ApartmentUpdateForm(forms.ModelForm):
             "description",
             "image",
             ButtonHolder(
-                Submit("update", "Update", css_class="btn btn-primary"),
-                Button(
-                    "cancel",
-                    "Cancel",
-                    css_class="btn btn-primary",
-                    onclick="history.back()",
+                Div(
+                    Div(
+                        Submit("update", "Update", css_class="btn btn-primary"),
+                        css_class="text-left",
+                    ),
+                    css_class="col col-sm-3",
+                ),
+                Div(
+                    Div(
+                        Button(
+                            "delete",
+                            "Delete",
+                            css_class="btn btn-primary",
+                            data_toggle="modal",
+                            data_target="#deleteModal",
+                        ),
+                        css_class="text-left",
+                    ),
+                    css_class="col-sm-3",
+                ),
+                Div(
+                    Div(
+                        Button(
+                            "cancel",
+                            "Cancel",
+                            css_class="btn btn-primary",
+                            onclick="history.back()",
+                        ),
+                        css_class="text-right",
+                    ),
+                    css_class="col col-sm-6",
                 ),
                 css_class="row justify-content-between",
             ),

--- a/location/templates/apartment.html
+++ b/location/templates/apartment.html
@@ -8,6 +8,11 @@
 
 {% load crispy_forms_tags %}
 
+{% block script %}
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
+  integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+{% endblock %}
+
 {% block content %}
 
 <!--Main layout-->
@@ -115,11 +120,7 @@
     <!--Grid row-->
 
     <hr>
-
   </div>
-
-
-
 </main>
 
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"

--- a/location/templates/apartment.html
+++ b/location/templates/apartment.html
@@ -122,8 +122,4 @@
     <hr>
   </div>
 </main>
-
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
-  integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-
 {% endblock %}

--- a/location/templates/apartment_update.html
+++ b/location/templates/apartment_update.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block script %}
-<!-- Allows us to us the Modal -->
+<!-- Allows us to show the Modal -->
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
   integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 {% endblock %}

--- a/location/templates/apartment_update.html
+++ b/location/templates/apartment_update.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load crispy_forms_tags %}
 
 {% block breadcrumbs %}
 <a href="{% url 'search' %}">Search</a>
@@ -7,7 +8,12 @@
 <span>Edit</span>
 {% endblock %}
 
-{% load crispy_forms_tags %}
+{% block script %}
+<!-- Allows us to us the Modal -->
+<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"
+  integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+{% endblock %}
+
 
 {% block content %}
 <h2>
@@ -32,4 +38,35 @@
         {% endif %}
     </div>
 </div>
+<<<<<<< HEAD
 {% endblock %}
+=======
+<!-- Modal -->
+<form method="POST" action="{% url 'apartment_delete' pk=object.location.id suite_num=object.suite_num %}" novalidate>
+    <!-- For some reason this form MUST be placed under the {% crispy apartment_form %} or you will -->
+    <!-- Get CSRF Violations when you try to submit this form -->
+    {% csrf_token %}
+    <div class="modal fade" id="deleteModal" tabindex="-1" role="dialog" aria-labelledby="deleteModalTitle"
+        aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="deleteModalTitle">Are you sure?</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <p>The apartment will be permenantly removed and will no longer show up in search results or in your
+                        account view.</p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                    <button type="submit" class="btn btn-danger">Delete</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</form>
+{% endblock %}
+>>>>>>> added UI

--- a/location/templates/apartment_update.html
+++ b/location/templates/apartment_update.html
@@ -38,9 +38,6 @@
         {% endif %}
     </div>
 </div>
-<<<<<<< HEAD
-{% endblock %}
-=======
 <!-- Modal -->
 <form method="POST" action="{% url 'apartment_delete' pk=object.location.id suite_num=object.suite_num %}" novalidate>
     <!-- For some reason this form MUST be placed under the {% crispy apartment_form %} or you will -->
@@ -69,4 +66,3 @@
     </div>
 </form>
 {% endblock %}
->>>>>>> added UI

--- a/location/tests.py
+++ b/location/tests.py
@@ -484,6 +484,20 @@ class LocationViewTests(TestCase):
         )
         self.assertRedirects(response, reverse("location", kwargs={"pk": loc.id}))
 
+    def test_apartment_delete_no_apartment(self):
+        """
+        insures that a 404 is thrown if the apartment doesn't exist
+        """
+        user = SiteUser.objects.create(username="testuser")
+        self.client.force_login(user)
+        loc, apa = self.create_location_and_apartment()
+        suite = apa.suite_num
+        apa.delete()
+        response = self.client.post(
+            reverse("apartment_delete", kwargs={"pk": loc.id, "suite_num": suite}), {}
+        )
+        self.assertEqual(response.status_code, 404)
+
     def test_contact_landlord_not_logged_in(self):
         """
         tests a GET response against the contact_landlord page

--- a/location/tests.py
+++ b/location/tests.py
@@ -410,24 +410,24 @@ class LocationViewTests(TestCase):
         )
         self.assertEqual(response.status_code, 403)
 
-    # def test_apartment_delete_get(self):
-    #     """
-    #     tests the apartment delete when it receives a GET instead of a POST
-    #     """
-    #     user = SiteUser.objects.create(username="testuser")
-    #     self.client.force_login(user)
-    #     loc, apa = self.create_location_and_apartment()
-    #     apa.landlord = user
-    #     apa.save()
-    #     response = self.client.get(
-    #         reverse(
-    #             "apartment_delete", kwargs={"pk": loc.id, "suite_num": apa.suite_num}
-    #         )
-    #     )
-    #     self.assertRedirects(
-    #         response,
-    #         reverse("apartment", kwargs={"pk": loc.id, "suite_num": apa.suite_num}),
-    #     )
+    def test_apartment_delete_get(self):
+        """
+        tests the apartment delete when it receives a GET instead of a POST
+        """
+        user = SiteUser.objects.create(username="testuser")
+        self.client.force_login(user)
+        loc, apa = self.create_location_and_apartment()
+        apa.landlord = user
+        apa.save()
+        response = self.client.get(
+            reverse(
+                "apartment_delete", kwargs={"pk": loc.id, "suite_num": apa.suite_num}
+            )
+        )
+        self.assertRedirects(
+            response,
+            reverse("apartment", kwargs={"pk": loc.id, "suite_num": apa.suite_num}),
+        )
 
     def test_apartment_delete(self):
         """

--- a/location/tests.py
+++ b/location/tests.py
@@ -204,6 +204,38 @@ class LocationViewTests(TestCase):
         response = self.client.post(reverse("apartment_upload"), post_data)
         self.assertRedirects(response, reverse("apartment_upload_confirmation"))
 
+    @mock.patch("location.views.fetch_geocode", fetch_geocode_stub)
+    def test_location_upload_negative_price(self):
+        """
+        tests uploading an apartment that has a negative rental price
+        """
+        self.client.force_login(SiteUser.objects.create(username="testuser"))
+
+        # Create a fake image
+        im = Image.new(mode="RGB", size=(200, 200))
+        im_io = BytesIO()
+        im.save(im_io, "JPEG")
+        im_io.seek(0)
+        mem_image = InMemoryUploadedFile(
+            im_io, None, "image.jpg", "image/jpeg", len(im_io.getvalue()), None
+        )
+
+        post_data = {
+            "city": "New York",
+            "state": "NY",
+            "address": "111 anytown st",
+            "zipcode": "10003",
+            "suite_num": "1",
+            "rent_price": -2500,
+            "number_of_bed": 1,
+            "description": "This is a test",
+            "image": mem_image,
+        }
+
+        response = self.client.post(reverse("apartment_upload"), post_data)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Rental price cannot be negative!")
+
     def test_location_edit_not_logged_in(self):
         """
         Tests the 'apartment_edit' page redirects when the user is not logged in

--- a/location/urls.py
+++ b/location/urls.py
@@ -18,6 +18,11 @@ urlpatterns = [
         views.apartment_edit,
         name="apartment_edit",
     ),
+    path(
+        "<int:pk>/apartment/<suite_num>/delete",
+        views.apartment_delete,
+        name="apartment_delete",
+    ),
     path("<int:pk>/favorite", views.favorites, name="favorite"),
     path("favlist", views.favlist, name="favlist"),
     path("<int:pk>/review", views.review, name="review"),

--- a/location/views.py
+++ b/location/views.py
@@ -88,14 +88,14 @@ def apartment_edit(request, pk, suite_num):
 
 @login_required
 def apartment_delete(request, pk, suite_num):
-    
+
     object = get_object_or_404(Apartment, location__id=pk, suite_num=suite_num)
     # check permissions
     if not object.landlord or (object.landlord != request.user):
         raise PermissionDenied
 
     if request.method == "POST":
-        result = object.delete()
+        object.delete()
         return HttpResponseRedirect(reverse("location", kwargs={"pk": pk}))
     else:
         return HttpResponseRedirect(

--- a/location/views.py
+++ b/location/views.py
@@ -87,6 +87,31 @@ def apartment_edit(request, pk, suite_num):
 
 
 @login_required
+def apartment_delete(request, pk, suite_num):
+    print("actual delete")
+    object = get_object_or_404(Apartment, location__id=pk, suite_num=suite_num)
+    # check permissions
+    if not object.landlord or (object.landlord != request.user):
+        raise PermissionDenied
+    print("blah 1")
+    print(f"request.post: {str(request.POST)}")
+    # if request.POST:
+    print("blah two")
+    result = object.delete()
+
+    print(f"number deleted: {result[0]}")
+    print("Reason: " + str(result[1]))
+    return HttpResponseRedirect(reverse("location", kwargs={"pk": pk}))
+
+
+# else:
+#    print("blah 3")
+#   return HttpResponseRedirect(
+#      reverse("apartment", kwargs={"pk": pk, "suite_num": suite_num})
+# )
+
+
+@login_required
 def claim_view(request, pk, suite_num):
     apt = Apartment.objects.get(location__id=pk, suite_num=suite_num)
 

--- a/location/views.py
+++ b/location/views.py
@@ -88,27 +88,19 @@ def apartment_edit(request, pk, suite_num):
 
 @login_required
 def apartment_delete(request, pk, suite_num):
-    print("actual delete")
+    
     object = get_object_or_404(Apartment, location__id=pk, suite_num=suite_num)
     # check permissions
     if not object.landlord or (object.landlord != request.user):
         raise PermissionDenied
-    print("blah 1")
-    print(f"request.post: {str(request.POST)}")
-    # if request.POST:
-    print("blah two")
-    result = object.delete()
 
-    print(f"number deleted: {result[0]}")
-    print("Reason: " + str(result[1]))
-    return HttpResponseRedirect(reverse("location", kwargs={"pk": pk}))
-
-
-# else:
-#    print("blah 3")
-#   return HttpResponseRedirect(
-#      reverse("apartment", kwargs={"pk": pk, "suite_num": suite_num})
-# )
+    if request.method == "POST":
+        result = object.delete()
+        return HttpResponseRedirect(reverse("location", kwargs={"pk": pk}))
+    else:
+        return HttpResponseRedirect(
+            reverse("apartment", kwargs={"pk": pk, "suite_num": suite_num})
+        )
 
 
 @login_required


### PR DESCRIPTION
This adds the ability for landlords to delete the apartments that they own.

Simply added a delete button to the apartment_update form
![image](https://user-images.githubusercontent.com/32490273/69483592-3bd32d00-0df7-11ea-9b01-f4b14cbcc08d.png)

which brings up a modal
![image](https://user-images.githubusercontent.com/32490273/69483599-4988b280-0df7-11ea-88d7-dcef9782b9d1.png)


Deleting the apartment returns the user to the location page.
