### PR TITLE
Bug - Admin view of CachedSearches

### DIFF
--- a/external/admin.py
+++ b/external/admin.py
@@ -1,1 +1,4 @@
-# from django.contrib import admin
+from django.contrib import admin
+from .models import CachedSearch
+
+admin.site.register(CachedSearch)


### PR DESCRIPTION
I realized that I forgot to register the CachedSearch model in the Admin view, which is an issue if you ever need to delete and refresh a cached search.