### PR TITLE
Storing Previous search

### DIFF
--- a/search/tests.py
+++ b/search/tests.py
@@ -288,9 +288,7 @@ class SearchIndexViewTests(TestCase):
             "bed_num": 4,
         }
         session.save()
-        # response = self.client.get(
-        #     "/search/?query=NY&min_price=500&max_price=2000&bed_num=4"
-        # )
+
         response = self.client.get("/search/")
         self.assertContains(response, "Address:")
         self.assertContains(response, "Max Price: 2000")

--- a/search/tests.py
+++ b/search/tests.py
@@ -276,6 +276,27 @@ class SearchIndexViewTests(TestCase):
             msg="Returned results when it shouldn't have",
         )
 
+    @mock.patch("search.views.fetch_craigslist_housing", fetch_craigslist_housing)
+    @mock.patch("external.nyc311.fetch.fetch_311_data", fetch_311_data)
+    @mock.patch("external.res.fetch.fetch_res_data", fetch_res_data)
+    def test_search_page_session(self):
+        session = self.client.session
+        session["last_query"] = {
+            "query": "NY",
+            "max_price": 2000,
+            "min_price": 500,
+            "bed_num": 4,
+        }
+        session.save()
+        # response = self.client.get(
+        #     "/search/?query=NY&min_price=500&max_price=2000&bed_num=4"
+        # )
+        response = self.client.get("/search/")
+        self.assertContains(response, "Address:")
+        self.assertContains(response, "Max Price: 2000")
+        self.assertContains(response, "Min Price: 500")
+        self.assertContains(response, "Number of Bedroom: 4")
+
 
 class SearchCraigsTests(TestCase):
     @mock.patch("search.views.fetch_craigslist_housing", fetch_craigslist_housing)

--- a/search/views.py
+++ b/search/views.py
@@ -27,7 +27,7 @@ def search(request):
         # if there isn't a current search query, check the user session to see
         # if there's a previously stored query
         if request.session.get("last_query", False) and not request.GET.get("query"):
-            print("getting session object")
+
             query["query"] = request.session["last_query"]["query"]
             query["min_price"] = request.session["last_query"]["min_price"]
             query["max_price"] = request.session["last_query"]["max_price"]
@@ -47,7 +47,6 @@ def search(request):
             if address:
                 zipcode = address.zipcode
 
-        # print(str(address))
         timeout = False
         max_price = query["max_price"]
         min_price = query["min_price"]


### PR DESCRIPTION
This PR is for automatically applying the last searched for search in the search index page when the user navigates back to it.  

This works pretty simply, when the user searches for apartments, the parameters that they searched for are stored in the current session.  This way if they navigate back to the search page their previous search can automatically be applied. If though they are performing a new search, the new search terms will take precedence and that will be what is displayed.

The benefit of this is we don't have to do a bunch of modifications to templates and view functions to insure that the search query parameters are being continuously passed from view to view.