### PR TITLE
Bug/fetch img description

### DIFF
--- a/location/templates/apartment.html
+++ b/location/templates/apartment.html
@@ -33,7 +33,7 @@
       <div class="col-md-6 mb-4">
 
       {% if apt.image %}
-          <img src="{{ apt.image.url }}" class="card-img-top contain" alt="apartment image" onerror="this.onerror=null; this.src='/static/img/no_img.png'">
+          <img src="{{ apt.image }}" class="card-img-top contain" alt="apartment image" onerror="this.onerror=null; this.src='/static/img/no_img.png'">
       {% else %}
           <img src="/static/img/no_img.png" class="card-img-top contain" alt="apartment image">
       {% endif %}

--- a/refresh_apartment/sample-response/craigslist-url-no-des.html
+++ b/refresh_apartment/sample-response/craigslist-url-no-des.html
@@ -1,0 +1,404 @@
+
+<!DOCTYPE html>
+<html class="no-js">
+<head>
+<title>At the side of Crown Heights awaits an undiscovered jewel!!!!!!!!!!!!! - apts/housing for rent - apartment rent</title>
+    	<link rel="canonical" href="https://newyork.craigslist.org/brk/apa/d/brooklyn-at-the-side-of-crown-heights/7030152301.html">
+	<meta name="description" content="At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly renovated apartment is...">
+	<meta name="geo.placename" content="Brooklyn">
+	<meta name="geo.position" content="40.671299;-73.927693">
+	<meta name="geo.region" content="US-NY">
+	<meta name="robots" content="noarchive,nofollow,unavailable_after: 31-Dec-19 13:04:39 EST">
+	<meta name="twitter:card" content="preview">
+	<meta property="og:description" content="At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly renovated apartment is...">
+	<meta property="og:image" content="https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg">
+	<meta property="og:site_name" content="craigslist">
+	<meta property="og:title" content="At the side of Crown Heights awaits an undiscovered jewel!!!!!!!!!!!!!">
+	<meta property="og:type" content="article">
+	<meta property="og:url" content="https://newyork.craigslist.org/brk/apa/d/brooklyn-at-the-side-of-crown-heights/7030152301.html">
+<meta name="viewport" content="width=device-width,initial-scale=1"><link type="text/css" rel="stylesheet" media="all" href="//www.craigslist.org/styles/cl.css?v=1c8b9f6ba76c1ce6e888ec5c48118861"><link type="text/css" rel="stylesheet" media="all" href="//www.craigslist.org/styles/postings.css?v=8e8653ebb6d18c400a76f7c352499623">    <link type="text/css" rel="stylesheet" media="all" href="//www.craigslist.org/styles/leaflet.css?v=33e3dd14c7deed955c83b6927c5e1f07">
+</head>
+
+<body class="posting">
+<script type="text/javascript"><!--
+    function C(k){return(document.cookie.match('(^|; )'+k+'=([^;]*)')||0)[2]}
+    var pagetype, pagemode;
+    (function(){
+        var h = document.documentElement;
+        h.className = h.className.replace('no-js', 'js');
+        var b = document.body;
+        var bodyClassList = b.className.split(/\s+/);;
+        pagetype = bodyClassList[0]; // dangerous assumption
+        var fmt = C('cl_fmt');
+        if ( fmt === 'regular' || fmt === 'mobile' ) {
+            pagemode = fmt;
+        } else if (screen.width <= 480) {
+            pagemode = 'mobile';
+        } else {
+            pagemode = 'regular';
+        }
+        pagemode = pagemode === 'mobile' ? 'mobile' : 'desktop';
+        bodyClassList.push(pagemode);
+        if (C('hidesearch') === '1' && pagemode !== 'mobile') {
+            bodyClassList.push('hide-search');
+        }
+        var width = window.innerWidth || document.documentElement.clientWidth;
+        if (width > 1000) { bodyClassList.push('w1024'); }
+        if (typeof window.sectionBase !== 'undefined') {
+            var mode = (decodeURIComponent(C('cl_tocmode') || '').match(new RegExp(window.sectionBase + ':([^,]+)', 'i')) || {})[1] || window.defaultView;
+            if (mode) {
+                bodyClassList.push(mode);
+            }
+        }
+        b.className = bodyClassList.join(' ');
+    }());
+--></script>
+
+    <section class="page-container">
+        <div class="bglogo"></div>
+<header class="global-header wide">
+   <a class="header-logo" name="logoLink" href="/">CL</a>
+
+    <nav class="breadcrumbs-container">
+
+<ul class="breadcrumbs">
+        <li class="crumb area">
+            <p>
+                    <a href="/">new york</a>
+
+                    <span class="breadcrumb-arrow">&gt;</span>
+            </p>
+        </li>
+
+        <li class="crumb subarea">
+            <p>
+                    <a href="/brk/">brooklyn</a>
+                    <span class="breadcrumb-arrow">&gt;</span>
+            </p>
+        </li>
+
+        <li class="crumb section">
+            <p>
+                    <a href="/search/brk/hhh">housing</a>
+
+                    <span class="breadcrumb-arrow">&gt;</span>
+            </p>
+        </li>
+
+        <li class="crumb category">
+            <p>
+                <a href="/search/brk/apa">apts/housing for rent</a>
+
+            </p>
+        </li>
+
+</ul>
+    </nav>
+
+<div class="userlinks">
+    <ul class="user-actions">
+        <li class="user post">
+            <a href="https://post.craigslist.org/c/nyc">post</a>
+        </li>
+        <li class="user account">
+            <a href="https://accounts.craigslist.org/login/home">account</a>
+        </li>
+    </ul>
+    <ul class="user-favs-discards">
+        <li class="user">
+            <div class="favorites">
+                <a href="#" class="favlink"><span class="icon icon-star fav" aria-hidden="true"></span><span class="fav-number"></span><span class="fav-label"> favorites</span></a>
+            </div>
+        </li>
+        <li class="user discards">
+          <form class="unfavform js-only" method="POST" action="/favorites">
+            <div class="to-banish-page">
+              <input type="hidden" class="lastLink" name="lastLink" value="/brk/apa/7030152301.html">
+              <input type="hidden" class="lastTitle" name="lastTitle" value="At the side of Crown Heights awaits an undiscovered jewel!!!!!!!!!!!!!">
+              <input type="hidden" class="unfaves" name="fl">
+              <input type="hidden" name="uf" value="1">
+              <a href="#" class="to-banish-page-link">
+                <span class="icon icon-trash red" aria-hidden="true"></span>
+                <span class="banished_count"></span>
+                <span class="discards-label"> hidden</span>
+              </a>
+            </div>
+          </form>
+        </li>
+    </ul>
+</div>
+
+</header>
+<header class="global-header narrow">
+   <a class="header-logo" href="/">CL</a>
+    <nav class="breadcrumbs-container">
+
+<ul class="breadcrumbs">
+
+
+brooklyn            &gt;
+
+apts/housing for rent
+
+</ul>
+
+
+    </nav>
+    <span class="linklike show-wide-header">...</span>
+</header>
+        <section class="body">
+<header class="dateReplyBar">
+    <div class="prevnext-sec">
+        <div class="prevnext js-only">
+    <a class="prev">&#9664;  prev </a>
+    <a class="backup" title="back to search">&#9650;</a>
+    <a class="next"> next &#9654; </a>
+</div>
+
+    </div>
+
+    <div class="reply-button-row">
+    <div class="actions-combo">
+    <button role="button" class="reply-button js-only" data-href="/__SERVICE_ID__/nyc/apa/7030152301">
+      reply
+    </button>
+
+      <div class="reply-info js-only"></div>
+    <div class="fave-unfave action">
+        <div class="fave" role="button"  title="add to favorites">
+            <div class="icon icon-star" aria-hidden="true"></div>
+            <div class="action-label">favorite</div>
+        </div>
+        <div class="unfave" role="button" title="remove from favorites">
+            <div class="icon icon-star fav" aria-hidden="true"></div>
+            <div class="action-label">favorite</div>
+        </div>
+    </div>
+<div class="banish-unbanish action">
+  <div class="banish" role="button"  title="hide this posting">
+    <div class="icon icon-trash" aria-hidden="true"></div>
+    <div class="action-label">hide</div>
+  </div>
+  <div class="unbanish" role="button"  title="restore this posting">
+    <div class="icon icon-trash red" aria-hidden="true"></div>
+    <div class="action-label">unhide</div>
+  </div>
+</div>
+    <div class="flag-action action">
+        <div class="flag" data-flag="28" role="button" title="flag as prohibited / spam / miscategorized" >
+            <div class="flagIcon" aria-hidden="true">
+                <span class="white-flag">&#9872</span>
+                <span class="black-flag">&#9873</span>
+            </div>
+            <div class="action-label">
+                flag
+            </div>
+        </div>
+        <div class="unflag">
+            <div class="flagIcon" aria-hidden="true">&#9873</div>
+            <a class="action-label" href="https://www.craigslist.org/about/help/flags_and_community_moderation" title="thanks for flagging!">
+                flagged
+            </a>
+        </div>
+    </div>
+    </div>
+
+            <p id="display-date" class="postinginfo reveal">
+                    Posted
+                    <time class="date timeago" datetime="2019-12-01T13:04:39-0500">
+                        2019-12-01 13:04
+                    </time>
+            </p>
+
+            <p class="print-information print-contact">
+                Contact Information: <span class="print-email"></span> <span class="print-phone"></span>
+            </p>
+            <a href="#" id="printme">print</a>
+
+    </div>
+
+</header>
+
+<h2 class="postingtitle">
+    <span class="postingtitletext">
+<span class="price">$1695</span> <span class="housing">/ 1br - </span><span id="titletextonly">At the side of Crown Heights awaits an undiscovered jewel!!!!!!!!!!!!!</span><small> (Sterling Pl / Crown Heights / Weeksville)</small>    </span>
+</h2>
+<section class="userbody">
+    <figure class="iw multiimage">
+    <div class="gallery">
+        <span class="slider-back arrow">&lt;</span>
+        <span class="slider-info">image 1 of 11</span>
+        <span class="slider-forward arrow">&gt;</span>
+
+        <div class="swipe">
+            <div class="swipe-wrap">
+                <div id="1_image_2JxY7yF7CiN" data-imgid="2JxY7yF7CiN" class="slide first visible">
+                    <img src="https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg" title="1" alt="1">
+                </div>
+                <div id="2_image_kLnDTCuX0n3" data-imgid="kLnDTCuX0n3" class="slide">
+                </div>
+                <div id="3_image_6cBvpsChesd" data-imgid="6cBvpsChesd" class="slide">
+                </div>
+                <div id="4_image_kwC30PtSw8A" data-imgid="kwC30PtSw8A" class="slide">
+                </div>
+                <div id="5_image_hQyjtD6axnH" data-imgid="hQyjtD6axnH" class="slide">
+                </div>
+                <div id="6_image_kLnDTCuX0n3" data-imgid="kLnDTCuX0n3" class="slide">
+                </div>
+                <div id="7_image_2csoBB7ipC2" data-imgid="2csoBB7ipC2" class="slide">
+                </div>
+                <div id="8_image_NSNZLRfqMP" data-imgid="NSNZLRfqMP" class="slide">
+                </div>
+                <div id="9_image_eJaKO7kUClc" data-imgid="eJaKO7kUClc" class="slide">
+                </div>
+                <div id="10_image_9Mk6G5ftRQl" data-imgid="9Mk6G5ftRQl" class="slide">
+                </div>
+                <div id="11_image_7DX6qw3liZd" data-imgid="7DX6qw3liZd" class="slide">
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="thumbs"><a id="1_thumb_2JxY7yF7CiN" class="thumb" data-imgid="2JxY7yF7CiN" href="https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg" title="1"><img src="https://images.craigslist.org/00H0H_2JxY7yF7CiN_50x50c.jpg" class="selected" alt="1"></a><a id="2_thumb_kLnDTCuX0n3" class="thumb" data-imgid="kLnDTCuX0n3" href="https://images.craigslist.org/00t0t_kLnDTCuX0n3_600x450.jpg" title="2"><img src="https://images.craigslist.org/00t0t_kLnDTCuX0n3_50x50c.jpg" alt="2"></a><a id="3_thumb_6cBvpsChesd" class="thumb" data-imgid="6cBvpsChesd" href="https://images.craigslist.org/01111_6cBvpsChesd_600x450.jpg" title="3"><img src="https://images.craigslist.org/01111_6cBvpsChesd_50x50c.jpg" alt="3"></a><a id="4_thumb_kwC30PtSw8A" class="thumb" data-imgid="kwC30PtSw8A" href="https://images.craigslist.org/00m0m_kwC30PtSw8A_600x450.jpg" title="4"><img src="https://images.craigslist.org/00m0m_kwC30PtSw8A_50x50c.jpg" alt="4"></a><a id="5_thumb_hQyjtD6axnH" class="thumb" data-imgid="hQyjtD6axnH" href="https://images.craigslist.org/01515_hQyjtD6axnH_600x450.jpg" title="5"><img src="https://images.craigslist.org/01515_hQyjtD6axnH_50x50c.jpg" alt="5"></a><a id="6_thumb_kLnDTCuX0n3" class="thumb" data-imgid="kLnDTCuX0n3" href="https://images.craigslist.org/00t0t_kLnDTCuX0n3_600x450.jpg" title="6"><img src="https://images.craigslist.org/00t0t_kLnDTCuX0n3_50x50c.jpg" alt="6"></a><a id="7_thumb_2csoBB7ipC2" class="thumb" data-imgid="2csoBB7ipC2" href="https://images.craigslist.org/00o0o_2csoBB7ipC2_600x450.jpg" title="7"><img src="https://images.craigslist.org/00o0o_2csoBB7ipC2_50x50c.jpg" alt="7"></a><a id="8_thumb_NSNZLRfqMP" class="thumb" data-imgid="NSNZLRfqMP" href="https://images.craigslist.org/00D0D_NSNZLRfqMP_600x450.jpg" title="8"><img src="https://images.craigslist.org/00D0D_NSNZLRfqMP_50x50c.jpg" alt="8"></a><a id="9_thumb_eJaKO7kUClc" class="thumb" data-imgid="eJaKO7kUClc" href="https://images.craigslist.org/00s0s_eJaKO7kUClc_600x450.jpg" title="9"><img src="https://images.craigslist.org/00s0s_eJaKO7kUClc_50x50c.jpg" alt="9"></a><a id="10_thumb_9Mk6G5ftRQl" class="thumb" data-imgid="9Mk6G5ftRQl" href="https://images.craigslist.org/00p0p_9Mk6G5ftRQl_600x450.jpg" title="10"><img src="https://images.craigslist.org/00p0p_9Mk6G5ftRQl_50x50c.jpg" alt="10"></a><a id="11_thumb_7DX6qw3liZd" class="thumb" data-imgid="7DX6qw3liZd" href="https://images.craigslist.org/01414_7DX6qw3liZd_600x450.jpg" title="11"><img src="https://images.craigslist.org/01414_7DX6qw3liZd_50x50c.jpg" alt="11"></a></div>
+
+        <script type="text/javascript"><!--
+var imgList = [{"shortid":"2JxY7yF7CiN","url":"https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg","thumb":"https://images.craigslist.org/00H0H_2JxY7yF7CiN_50x50c.jpg","imgid":"1:00H0H_2JxY7yF7CiN"},{"shortid":"kLnDTCuX0n3","url":"https://images.craigslist.org/00t0t_kLnDTCuX0n3_600x450.jpg","thumb":"https://images.craigslist.org/00t0t_kLnDTCuX0n3_50x50c.jpg","imgid":"1:00t0t_kLnDTCuX0n3"},{"shortid":"6cBvpsChesd","url":"https://images.craigslist.org/01111_6cBvpsChesd_600x450.jpg","thumb":"https://images.craigslist.org/01111_6cBvpsChesd_50x50c.jpg","imgid":"1:01111_6cBvpsChesd"},{"shortid":"kwC30PtSw8A","url":"https://images.craigslist.org/00m0m_kwC30PtSw8A_600x450.jpg","thumb":"https://images.craigslist.org/00m0m_kwC30PtSw8A_50x50c.jpg","imgid":"1:00m0m_kwC30PtSw8A"},{"shortid":"hQyjtD6axnH","url":"https://images.craigslist.org/01515_hQyjtD6axnH_600x450.jpg","thumb":"https://images.craigslist.org/01515_hQyjtD6axnH_50x50c.jpg","imgid":"1:01515_hQyjtD6axnH"},{"shortid":"kLnDTCuX0n3","url":"https://images.craigslist.org/00t0t_kLnDTCuX0n3_600x450.jpg","thumb":"https://images.craigslist.org/00t0t_kLnDTCuX0n3_50x50c.jpg","imgid":"1:00t0t_kLnDTCuX0n3"},{"shortid":"2csoBB7ipC2","url":"https://images.craigslist.org/00o0o_2csoBB7ipC2_600x450.jpg","thumb":"https://images.craigslist.org/00o0o_2csoBB7ipC2_50x50c.jpg","imgid":"1:00o0o_2csoBB7ipC2"},{"shortid":"NSNZLRfqMP","url":"https://images.craigslist.org/00D0D_NSNZLRfqMP_600x450.jpg","thumb":"https://images.craigslist.org/00D0D_NSNZLRfqMP_50x50c.jpg","imgid":"1:00D0D_NSNZLRfqMP"},{"shortid":"eJaKO7kUClc","url":"https://images.craigslist.org/00s0s_eJaKO7kUClc_600x450.jpg","thumb":"https://images.craigslist.org/00s0s_eJaKO7kUClc_50x50c.jpg","imgid":"1:00s0s_eJaKO7kUClc"},{"shortid":"9Mk6G5ftRQl","url":"https://images.craigslist.org/00p0p_9Mk6G5ftRQl_600x450.jpg","thumb":"https://images.craigslist.org/00p0p_9Mk6G5ftRQl_50x50c.jpg","imgid":"1:00p0p_9Mk6G5ftRQl"},{"shortid":"7DX6qw3liZd","url":"https://images.craigslist.org/01414_7DX6qw3liZd_600x450.jpg","thumb":"https://images.craigslist.org/01414_7DX6qw3liZd_50x50c.jpg","imgid":"1:01414_7DX6qw3liZd"}];
+--></script>
+
+</figure>
+
+
+    <div class="mapAndAttrs">
+<div class="mapbox">
+    <div id="map" class="viewposting" data-latitude="40.671299" data-longitude="-73.927693" data-accuracy="10"></div>
+    <div class="mapaddress">1540 Sterling Pl</div>
+    <p class="mapaddress">
+        <small>
+        (<a target="_blank" href="https://www.google.com/maps/preview/@40.671299,-73.927693,16z">google map</a>)
+        </small>
+    </p>
+</div>
+
+    <p class="attrgroup">
+
+
+
+            <span class="shared-line-bubble"><b>1BR</b> / <b>1Ba</b></span>
+
+
+
+
+            <span class="housing_movein_now property_date shared-line-bubble" data-date="2019-12-01" data-today_msg="available now">available dec 1</span>
+
+    </p>
+    <p class="attrgroup">
+
+
+
+            <span>application fee details: <b>$20 credit app</b></span>
+            <br>
+
+
+
+
+            <span>apartment</span>
+            <br>
+
+    </p>
+    </div>
+
+<ul class="notices">
+            <li>do NOT contact me with unsolicited services or offers</li>
+</ul>
+
+    <div class="postinginfos">
+            <p class="postinginfo">post id: 7030152301</p>
+                <p class="postinginfo reveal">posted: <time class="date timeago" datetime="2019-12-01T13:04:39-0500">2019-12-01 13:04</time></p>
+
+
+               <p class="postinginfo">
+                   <a href="https://accounts.craigslist.org/eaf?postingID=7030152301&amp;token=U2FsdGVkX18xNzkxNTE3OZajN96iJGZ_hc8PBiLJgwQvhfUutvGRFScGE23YqG6Y" class="email-friend">email to friend</a>
+               </p>
+        <p class="postinginfo">
+              <a class="bestof-link" data-flag="9" href="https://post.craigslist.org/flag?flagCode=9&amp;postingID=7030152301" title="nominate for best-of-CL">
+                <span class="bestof-icon">&hearts; </span><span class="bestof-text">best of</span>
+              </a> <sup>[<a href="https://www.craigslist.org/about/best-of-craigslist">?</a>]</sup>
+        </p>
+
+    </div>
+
+    <div class="print-information print-pics"></div>
+
+</section>
+
+<div class="psa-box">
+</div>
+
+<div class="avoid-scams">
+<aside class="tsb">
+    Please flag
+    <a href="https://www.craigslist.org/about/FHA">discriminatory housing ads</a>
+</aside>
+
+<aside class="tsb">
+    <a href="https://www.craigslist.org/about/scams">Avoid scams, deal locally!</a>
+
+    <em>DO NOT wire funds (e.g. Western Union)</em>, or buy/rent sight unseen
+</aside>
+</div>
+
+        </section>
+<footer>
+    <ul class="clfooter">
+        <li>&copy;  <span class="desktop">craigslist</span><span class="mobile">CL</span></li>
+        <li><a href="https://www.craigslist.org/about/help/">help</a></li>
+        <li><a href="https://www.craigslist.org/about/scams">safety</a></li>
+        <li class="desktop"><a href="https://www.craigslist.org/about/privacy.policy">privacy</a></li>
+        <li class="desktop"><a href="https://forums.craigslist.org/?forumID=8">feedback</a></li>
+        <li class="desktop"><a href="https://www.craigslist.org/about/craigslist_is_hiring">cl jobs</a></li>
+        <li><a href="//www.craigslist.org/about/terms.of.use.en-us">terms</a><sup class="neu">new</sup></li>
+        <li><a href="https://www.craigslist.org/about/">about</a></li>
+        <li class="fsel desktop linklike" data-mode="mobile">mobile</li>
+        <li class="fsel mobile linklike" data-mode="regular">desktop</li>
+    </ul>
+</footer>
+    </section>
+
+
+        <script type="text/javascript"><!--
+var countOfTotalText = "image {count} of {total}";
+var imageConfig = {"1":{"hostname":"https://images.craigslist.org","sizes":["50x50c","300x300","600x450","1200x900"]},"0":{"hostname":"https://images.craigslist.org","sizes":["50x50c","300x300","600x450"]},"2":{"hostname":"https://images.craigslist.org","sizes":["50x50c","300x300","600x450","1200x900"]}};
+var maptileBaseUrl = "//map{s}.craigslist.org/t09/{z}/{x}/{y}.png";
+var pID = 7030152301;
+--></script>
+
+
+                <script>
+                try {
+                    if (
+                        !/\/\/.+\.craigslist\.org\/about\//.test(window.location.href)
+                        &&
+                        (!window.addEventListener || JSON.parse(JSON.stringify('x')) !== 'x')
+                    ) {
+                        throw "unsupported browser";
+                    }
+                } catch (e) {
+                    function cleanup() {
+                        document.body.innerHTML = '<div id="cl-unsupported-browser" style="margin:1em;font-size:150%;text-align:center;">We have detected you are using a browser that is missing critical features.<br><br>Please visit craigslist from a modern browser.</div>';
+                        document.body.style = "display:block";
+                    }
+
+                    try {
+                        document.body.style = "display:none";
+                    } catch (e) {
+                    }
+                    window.onload = cleanup;
+                    window.clUnsupportedBrowser = true;
+                }
+                </script>
+            <script src="//www.craigslist.org/js/general-concat.min.js?v=465a7dfa244af27ef2e11cc4f6c861aa" type="text/javascript" ></script>
+
+    <script src="//www.craigslist.org/js/leaflet-concat.min.js?v=e7a0a603160389eb711fc27bba8a20d9" type="text/javascript" ></script>
+
+<script src="//www.craigslist.org/js/postings-concat.min.js?v=50246caae35394381230131c050ac7f6" type="text/javascript" ></script>
+</body>
+</html>

--- a/refresh_apartment/sample-response/craigslist-url-no-pic-no-des.html
+++ b/refresh_apartment/sample-response/craigslist-url-no-pic-no-des.html
@@ -1,0 +1,375 @@
+
+<!DOCTYPE html>
+<html class="no-js">
+<head>
+<title>At the side of Crown Heights awaits an undiscovered jewel!!!!!!!!!!!!! - apts/housing for rent - apartment rent</title>
+    	<link rel="canonical" href="https://newyork.craigslist.org/brk/apa/d/brooklyn-at-the-side-of-crown-heights/7030152301.html">
+	<meta name="description" content="At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly renovated apartment is...">
+	<meta name="geo.placename" content="Brooklyn">
+	<meta name="geo.position" content="40.671299;-73.927693">
+	<meta name="geo.region" content="US-NY">
+	<meta name="robots" content="noarchive,nofollow,unavailable_after: 31-Dec-19 13:04:39 EST">
+	<meta name="twitter:card" content="preview">
+	<meta property="og:description" content="At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly renovated apartment is...">
+	<meta property="og:image" content="https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg">
+	<meta property="og:site_name" content="craigslist">
+	<meta property="og:title" content="At the side of Crown Heights awaits an undiscovered jewel!!!!!!!!!!!!!">
+	<meta property="og:type" content="article">
+	<meta property="og:url" content="https://newyork.craigslist.org/brk/apa/d/brooklyn-at-the-side-of-crown-heights/7030152301.html">
+<meta name="viewport" content="width=device-width,initial-scale=1"><link type="text/css" rel="stylesheet" media="all" href="//www.craigslist.org/styles/cl.css?v=1c8b9f6ba76c1ce6e888ec5c48118861"><link type="text/css" rel="stylesheet" media="all" href="//www.craigslist.org/styles/postings.css?v=8e8653ebb6d18c400a76f7c352499623">    <link type="text/css" rel="stylesheet" media="all" href="//www.craigslist.org/styles/leaflet.css?v=33e3dd14c7deed955c83b6927c5e1f07">
+</head>
+
+<body class="posting">
+<script type="text/javascript"><!--
+    function C(k){return(document.cookie.match('(^|; )'+k+'=([^;]*)')||0)[2]}
+    var pagetype, pagemode;
+    (function(){
+        var h = document.documentElement;
+        h.className = h.className.replace('no-js', 'js');
+        var b = document.body;
+        var bodyClassList = b.className.split(/\s+/);;
+        pagetype = bodyClassList[0]; // dangerous assumption
+        var fmt = C('cl_fmt');
+        if ( fmt === 'regular' || fmt === 'mobile' ) {
+            pagemode = fmt;
+        } else if (screen.width <= 480) {
+            pagemode = 'mobile';
+        } else {
+            pagemode = 'regular';
+        }
+        pagemode = pagemode === 'mobile' ? 'mobile' : 'desktop';
+        bodyClassList.push(pagemode);
+        if (C('hidesearch') === '1' && pagemode !== 'mobile') {
+            bodyClassList.push('hide-search');
+        }
+        var width = window.innerWidth || document.documentElement.clientWidth;
+        if (width > 1000) { bodyClassList.push('w1024'); }
+        if (typeof window.sectionBase !== 'undefined') {
+            var mode = (decodeURIComponent(C('cl_tocmode') || '').match(new RegExp(window.sectionBase + ':([^,]+)', 'i')) || {})[1] || window.defaultView;
+            if (mode) {
+                bodyClassList.push(mode);
+            }
+        }
+        b.className = bodyClassList.join(' ');
+    }());
+--></script>
+
+    <section class="page-container">
+        <div class="bglogo"></div>
+<header class="global-header wide">
+   <a class="header-logo" name="logoLink" href="/">CL</a>
+
+    <nav class="breadcrumbs-container">
+
+<ul class="breadcrumbs">
+        <li class="crumb area">
+            <p>
+                    <a href="/">new york</a>
+
+                    <span class="breadcrumb-arrow">&gt;</span>
+            </p>
+        </li>
+
+        <li class="crumb subarea">
+            <p>
+                    <a href="/brk/">brooklyn</a>
+                    <span class="breadcrumb-arrow">&gt;</span>
+            </p>
+        </li>
+
+        <li class="crumb section">
+            <p>
+                    <a href="/search/brk/hhh">housing</a>
+
+                    <span class="breadcrumb-arrow">&gt;</span>
+            </p>
+        </li>
+
+        <li class="crumb category">
+            <p>
+                <a href="/search/brk/apa">apts/housing for rent</a>
+
+            </p>
+        </li>
+
+</ul>
+    </nav>
+
+<div class="userlinks">
+    <ul class="user-actions">
+        <li class="user post">
+            <a href="https://post.craigslist.org/c/nyc">post</a>
+        </li>
+        <li class="user account">
+            <a href="https://accounts.craigslist.org/login/home">account</a>
+        </li>
+    </ul>
+    <ul class="user-favs-discards">
+        <li class="user">
+            <div class="favorites">
+                <a href="#" class="favlink"><span class="icon icon-star fav" aria-hidden="true"></span><span class="fav-number"></span><span class="fav-label"> favorites</span></a>
+            </div>
+        </li>
+        <li class="user discards">
+          <form class="unfavform js-only" method="POST" action="/favorites">
+            <div class="to-banish-page">
+              <input type="hidden" class="lastLink" name="lastLink" value="/brk/apa/7030152301.html">
+              <input type="hidden" class="lastTitle" name="lastTitle" value="At the side of Crown Heights awaits an undiscovered jewel!!!!!!!!!!!!!">
+              <input type="hidden" class="unfaves" name="fl">
+              <input type="hidden" name="uf" value="1">
+              <a href="#" class="to-banish-page-link">
+                <span class="icon icon-trash red" aria-hidden="true"></span>
+                <span class="banished_count"></span>
+                <span class="discards-label"> hidden</span>
+              </a>
+            </div>
+          </form>
+        </li>
+    </ul>
+</div>
+
+</header>
+<header class="global-header narrow">
+   <a class="header-logo" href="/">CL</a>
+    <nav class="breadcrumbs-container">
+
+<ul class="breadcrumbs">
+
+
+brooklyn            &gt;
+
+apts/housing for rent
+
+</ul>
+
+
+    </nav>
+    <span class="linklike show-wide-header">...</span>
+</header>
+        <section class="body">
+<header class="dateReplyBar">
+    <div class="prevnext-sec">
+        <div class="prevnext js-only">
+    <a class="prev">&#9664;  prev </a>
+    <a class="backup" title="back to search">&#9650;</a>
+    <a class="next"> next &#9654; </a>
+</div>
+
+    </div>
+
+    <div class="reply-button-row">
+    <div class="actions-combo">
+    <button role="button" class="reply-button js-only" data-href="/__SERVICE_ID__/nyc/apa/7030152301">
+      reply
+    </button>
+
+      <div class="reply-info js-only"></div>
+    <div class="fave-unfave action">
+        <div class="fave" role="button"  title="add to favorites">
+            <div class="icon icon-star" aria-hidden="true"></div>
+            <div class="action-label">favorite</div>
+        </div>
+        <div class="unfave" role="button" title="remove from favorites">
+            <div class="icon icon-star fav" aria-hidden="true"></div>
+            <div class="action-label">favorite</div>
+        </div>
+    </div>
+<div class="banish-unbanish action">
+  <div class="banish" role="button"  title="hide this posting">
+    <div class="icon icon-trash" aria-hidden="true"></div>
+    <div class="action-label">hide</div>
+  </div>
+  <div class="unbanish" role="button"  title="restore this posting">
+    <div class="icon icon-trash red" aria-hidden="true"></div>
+    <div class="action-label">unhide</div>
+  </div>
+</div>
+    <div class="flag-action action">
+        <div class="flag" data-flag="28" role="button" title="flag as prohibited / spam / miscategorized" >
+            <div class="flagIcon" aria-hidden="true">
+                <span class="white-flag">&#9872</span>
+                <span class="black-flag">&#9873</span>
+            </div>
+            <div class="action-label">
+                flag
+            </div>
+        </div>
+        <div class="unflag">
+            <div class="flagIcon" aria-hidden="true">&#9873</div>
+            <a class="action-label" href="https://www.craigslist.org/about/help/flags_and_community_moderation" title="thanks for flagging!">
+                flagged
+            </a>
+        </div>
+    </div>
+    </div>
+
+            <p id="display-date" class="postinginfo reveal">
+                    Posted
+                    <time class="date timeago" datetime="2019-12-01T13:04:39-0500">
+                        2019-12-01 13:04
+                    </time>
+            </p>
+
+            <p class="print-information print-contact">
+                Contact Information: <span class="print-email"></span> <span class="print-phone"></span>
+            </p>
+            <a href="#" id="printme">print</a>
+
+    </div>
+
+</header>
+
+<h2 class="postingtitle">
+    <span class="postingtitletext">
+<span class="price">$1695</span> <span class="housing">/ 1br - </span><span id="titletextonly">At the side of Crown Heights awaits an undiscovered jewel!!!!!!!!!!!!!</span><small> (Sterling Pl / Crown Heights / Weeksville)</small>    </span>
+</h2>
+<section class="userbody">
+    <figure class="iw multiimage">
+    <div class="gallery">
+        <span class="slider-back arrow">&lt;</span>
+        <span class="slider-info">image 1 of 11</span>
+        <span class="slider-forward arrow">&gt;</span>
+
+
+    </div>
+        <script type="text/javascript"><!--
+--></script>
+
+</figure>
+
+
+    <div class="mapAndAttrs">
+<div class="mapbox">
+    <div id="map" class="viewposting" data-latitude="40.671299" data-longitude="-73.927693" data-accuracy="10"></div>
+    <div class="mapaddress">1540 Sterling Pl</div>
+    <p class="mapaddress">
+        <small>
+        (<a target="_blank" href="https://www.google.com/maps/preview/@40.671299,-73.927693,16z">google map</a>)
+        </small>
+    </p>
+</div>
+
+    <p class="attrgroup">
+
+
+
+            <span class="shared-line-bubble"><b>1BR</b> / <b>1Ba</b></span>
+
+
+
+
+            <span class="housing_movein_now property_date shared-line-bubble" data-date="2019-12-01" data-today_msg="available now">available dec 1</span>
+
+    </p>
+    <p class="attrgroup">
+
+
+
+            <span>application fee details: <b>$20 credit app</b></span>
+            <br>
+
+
+
+
+            <span>apartment</span>
+            <br>
+
+    </p>
+    </div>
+
+<ul class="notices">
+            <li>do NOT contact me with unsolicited services or offers</li>
+</ul>
+
+    <div class="postinginfos">
+            <p class="postinginfo">post id: 7030152301</p>
+                <p class="postinginfo reveal">posted: <time class="date timeago" datetime="2019-12-01T13:04:39-0500">2019-12-01 13:04</time></p>
+
+
+               <p class="postinginfo">
+                   <a href="https://accounts.craigslist.org/eaf?postingID=7030152301&amp;token=U2FsdGVkX18xNzkxNTE3OZajN96iJGZ_hc8PBiLJgwQvhfUutvGRFScGE23YqG6Y" class="email-friend">email to friend</a>
+               </p>
+        <p class="postinginfo">
+              <a class="bestof-link" data-flag="9" href="https://post.craigslist.org/flag?flagCode=9&amp;postingID=7030152301" title="nominate for best-of-CL">
+                <span class="bestof-icon">&hearts; </span><span class="bestof-text">best of</span>
+              </a> <sup>[<a href="https://www.craigslist.org/about/best-of-craigslist">?</a>]</sup>
+        </p>
+
+    </div>
+
+    <div class="print-information print-pics"></div>
+
+</section>
+
+<div class="psa-box">
+</div>
+
+<div class="avoid-scams">
+<aside class="tsb">
+    Please flag
+    <a href="https://www.craigslist.org/about/FHA">discriminatory housing ads</a>
+</aside>
+
+<aside class="tsb">
+    <a href="https://www.craigslist.org/about/scams">Avoid scams, deal locally!</a>
+
+    <em>DO NOT wire funds (e.g. Western Union)</em>, or buy/rent sight unseen
+</aside>
+</div>
+
+        </section>
+<footer>
+    <ul class="clfooter">
+        <li>&copy;  <span class="desktop">craigslist</span><span class="mobile">CL</span></li>
+        <li><a href="https://www.craigslist.org/about/help/">help</a></li>
+        <li><a href="https://www.craigslist.org/about/scams">safety</a></li>
+        <li class="desktop"><a href="https://www.craigslist.org/about/privacy.policy">privacy</a></li>
+        <li class="desktop"><a href="https://forums.craigslist.org/?forumID=8">feedback</a></li>
+        <li class="desktop"><a href="https://www.craigslist.org/about/craigslist_is_hiring">cl jobs</a></li>
+        <li><a href="//www.craigslist.org/about/terms.of.use.en-us">terms</a><sup class="neu">new</sup></li>
+        <li><a href="https://www.craigslist.org/about/">about</a></li>
+        <li class="fsel desktop linklike" data-mode="mobile">mobile</li>
+        <li class="fsel mobile linklike" data-mode="regular">desktop</li>
+    </ul>
+</footer>
+    </section>
+
+
+        <script type="text/javascript"><!--
+var countOfTotalText = "image {count} of {total}";
+var imageConfig = {"1":{"hostname":"https://images.craigslist.org","sizes":["50x50c","300x300","600x450","1200x900"]},"0":{"hostname":"https://images.craigslist.org","sizes":["50x50c","300x300","600x450"]},"2":{"hostname":"https://images.craigslist.org","sizes":["50x50c","300x300","600x450","1200x900"]}};
+var maptileBaseUrl = "//map{s}.craigslist.org/t09/{z}/{x}/{y}.png";
+var pID = 7030152301;
+--></script>
+
+
+                <script>
+                try {
+                    if (
+                        !/\/\/.+\.craigslist\.org\/about\//.test(window.location.href)
+                        &&
+                        (!window.addEventListener || JSON.parse(JSON.stringify('x')) !== 'x')
+                    ) {
+                        throw "unsupported browser";
+                    }
+                } catch (e) {
+                    function cleanup() {
+                        document.body.innerHTML = '<div id="cl-unsupported-browser" style="margin:1em;font-size:150%;text-align:center;">We have detected you are using a browser that is missing critical features.<br><br>Please visit craigslist from a modern browser.</div>';
+                        document.body.style = "display:block";
+                    }
+
+                    try {
+                        document.body.style = "display:none";
+                    } catch (e) {
+                    }
+                    window.onload = cleanup;
+                    window.clUnsupportedBrowser = true;
+                }
+                </script>
+            <script src="//www.craigslist.org/js/general-concat.min.js?v=465a7dfa244af27ef2e11cc4f6c861aa" type="text/javascript" ></script>
+
+    <script src="//www.craigslist.org/js/leaflet-concat.min.js?v=e7a0a603160389eb711fc27bba8a20d9" type="text/javascript" ></script>
+
+<script src="//www.craigslist.org/js/postings-concat.min.js?v=50246caae35394381230131c050ac7f6" type="text/javascript" ></script>
+</body>
+</html>

--- a/refresh_apartment/sample-response/craigslist-url-no-pic.html
+++ b/refresh_apartment/sample-response/craigslist-url-no-pic.html
@@ -1,0 +1,398 @@
+
+<!DOCTYPE html>
+<html class="no-js">
+<head>
+<title>At the side of Crown Heights awaits an undiscovered jewel!!!!!!!!!!!!! - apts/housing for rent - apartment rent</title>
+    	<link rel="canonical" href="https://newyork.craigslist.org/brk/apa/d/brooklyn-at-the-side-of-crown-heights/7030152301.html">
+	<meta name="description" content="At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly renovated apartment is...">
+	<meta name="geo.placename" content="Brooklyn">
+	<meta name="geo.position" content="40.671299;-73.927693">
+	<meta name="geo.region" content="US-NY">
+	<meta name="robots" content="noarchive,nofollow,unavailable_after: 31-Dec-19 13:04:39 EST">
+	<meta name="twitter:card" content="preview">
+	<meta property="og:description" content="At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly renovated apartment is...">
+	<meta property="og:image" content="https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg">
+	<meta property="og:site_name" content="craigslist">
+	<meta property="og:title" content="At the side of Crown Heights awaits an undiscovered jewel!!!!!!!!!!!!!">
+	<meta property="og:type" content="article">
+	<meta property="og:url" content="https://newyork.craigslist.org/brk/apa/d/brooklyn-at-the-side-of-crown-heights/7030152301.html">
+<meta name="viewport" content="width=device-width,initial-scale=1"><link type="text/css" rel="stylesheet" media="all" href="//www.craigslist.org/styles/cl.css?v=1c8b9f6ba76c1ce6e888ec5c48118861"><link type="text/css" rel="stylesheet" media="all" href="//www.craigslist.org/styles/postings.css?v=8e8653ebb6d18c400a76f7c352499623">    <link type="text/css" rel="stylesheet" media="all" href="//www.craigslist.org/styles/leaflet.css?v=33e3dd14c7deed955c83b6927c5e1f07">
+</head>
+
+<body class="posting">
+<script type="text/javascript"><!--
+    function C(k){return(document.cookie.match('(^|; )'+k+'=([^;]*)')||0)[2]}
+    var pagetype, pagemode;
+    (function(){
+        var h = document.documentElement;
+        h.className = h.className.replace('no-js', 'js');
+        var b = document.body;
+        var bodyClassList = b.className.split(/\s+/);;
+        pagetype = bodyClassList[0]; // dangerous assumption
+        var fmt = C('cl_fmt');
+        if ( fmt === 'regular' || fmt === 'mobile' ) {
+            pagemode = fmt;
+        } else if (screen.width <= 480) {
+            pagemode = 'mobile';
+        } else {
+            pagemode = 'regular';
+        }
+        pagemode = pagemode === 'mobile' ? 'mobile' : 'desktop';
+        bodyClassList.push(pagemode);
+        if (C('hidesearch') === '1' && pagemode !== 'mobile') {
+            bodyClassList.push('hide-search');
+        }
+        var width = window.innerWidth || document.documentElement.clientWidth;
+        if (width > 1000) { bodyClassList.push('w1024'); }
+        if (typeof window.sectionBase !== 'undefined') {
+            var mode = (decodeURIComponent(C('cl_tocmode') || '').match(new RegExp(window.sectionBase + ':([^,]+)', 'i')) || {})[1] || window.defaultView;
+            if (mode) {
+                bodyClassList.push(mode);
+            }
+        }
+        b.className = bodyClassList.join(' ');
+    }());
+--></script>
+
+    <section class="page-container">
+        <div class="bglogo"></div>
+<header class="global-header wide">
+   <a class="header-logo" name="logoLink" href="/">CL</a>
+
+    <nav class="breadcrumbs-container">
+
+<ul class="breadcrumbs">
+        <li class="crumb area">
+            <p>
+                    <a href="/">new york</a>
+
+                    <span class="breadcrumb-arrow">&gt;</span>
+            </p>
+        </li>
+
+        <li class="crumb subarea">
+            <p>
+                    <a href="/brk/">brooklyn</a>
+                    <span class="breadcrumb-arrow">&gt;</span>
+            </p>
+        </li>
+
+        <li class="crumb section">
+            <p>
+                    <a href="/search/brk/hhh">housing</a>
+
+                    <span class="breadcrumb-arrow">&gt;</span>
+            </p>
+        </li>
+
+        <li class="crumb category">
+            <p>
+                <a href="/search/brk/apa">apts/housing for rent</a>
+
+            </p>
+        </li>
+
+</ul>
+    </nav>
+
+<div class="userlinks">
+    <ul class="user-actions">
+        <li class="user post">
+            <a href="https://post.craigslist.org/c/nyc">post</a>
+        </li>
+        <li class="user account">
+            <a href="https://accounts.craigslist.org/login/home">account</a>
+        </li>
+    </ul>
+    <ul class="user-favs-discards">
+        <li class="user">
+            <div class="favorites">
+                <a href="#" class="favlink"><span class="icon icon-star fav" aria-hidden="true"></span><span class="fav-number"></span><span class="fav-label"> favorites</span></a>
+            </div>
+        </li>
+        <li class="user discards">
+          <form class="unfavform js-only" method="POST" action="/favorites">
+            <div class="to-banish-page">
+              <input type="hidden" class="lastLink" name="lastLink" value="/brk/apa/7030152301.html">
+              <input type="hidden" class="lastTitle" name="lastTitle" value="At the side of Crown Heights awaits an undiscovered jewel!!!!!!!!!!!!!">
+              <input type="hidden" class="unfaves" name="fl">
+              <input type="hidden" name="uf" value="1">
+              <a href="#" class="to-banish-page-link">
+                <span class="icon icon-trash red" aria-hidden="true"></span>
+                <span class="banished_count"></span>
+                <span class="discards-label"> hidden</span>
+              </a>
+            </div>
+          </form>
+        </li>
+    </ul>
+</div>
+
+</header>
+<header class="global-header narrow">
+   <a class="header-logo" href="/">CL</a>
+    <nav class="breadcrumbs-container">
+
+<ul class="breadcrumbs">
+
+
+brooklyn            &gt;
+
+apts/housing for rent
+
+</ul>
+
+
+    </nav>
+    <span class="linklike show-wide-header">...</span>
+</header>
+        <section class="body">
+<header class="dateReplyBar">
+    <div class="prevnext-sec">
+        <div class="prevnext js-only">
+    <a class="prev">&#9664;  prev </a>
+    <a class="backup" title="back to search">&#9650;</a>
+    <a class="next"> next &#9654; </a>
+</div>
+
+    </div>
+
+    <div class="reply-button-row">
+    <div class="actions-combo">
+    <button role="button" class="reply-button js-only" data-href="/__SERVICE_ID__/nyc/apa/7030152301">
+      reply
+    </button>
+
+      <div class="reply-info js-only"></div>
+    <div class="fave-unfave action">
+        <div class="fave" role="button"  title="add to favorites">
+            <div class="icon icon-star" aria-hidden="true"></div>
+            <div class="action-label">favorite</div>
+        </div>
+        <div class="unfave" role="button" title="remove from favorites">
+            <div class="icon icon-star fav" aria-hidden="true"></div>
+            <div class="action-label">favorite</div>
+        </div>
+    </div>
+<div class="banish-unbanish action">
+  <div class="banish" role="button"  title="hide this posting">
+    <div class="icon icon-trash" aria-hidden="true"></div>
+    <div class="action-label">hide</div>
+  </div>
+  <div class="unbanish" role="button"  title="restore this posting">
+    <div class="icon icon-trash red" aria-hidden="true"></div>
+    <div class="action-label">unhide</div>
+  </div>
+</div>
+    <div class="flag-action action">
+        <div class="flag" data-flag="28" role="button" title="flag as prohibited / spam / miscategorized" >
+            <div class="flagIcon" aria-hidden="true">
+                <span class="white-flag">&#9872</span>
+                <span class="black-flag">&#9873</span>
+            </div>
+            <div class="action-label">
+                flag
+            </div>
+        </div>
+        <div class="unflag">
+            <div class="flagIcon" aria-hidden="true">&#9873</div>
+            <a class="action-label" href="https://www.craigslist.org/about/help/flags_and_community_moderation" title="thanks for flagging!">
+                flagged
+            </a>
+        </div>
+    </div>
+    </div>
+
+            <p id="display-date" class="postinginfo reveal">
+                    Posted
+                    <time class="date timeago" datetime="2019-12-01T13:04:39-0500">
+                        2019-12-01 13:04
+                    </time>
+            </p>
+
+            <p class="print-information print-contact">
+                Contact Information: <span class="print-email"></span> <span class="print-phone"></span>
+            </p>
+            <a href="#" id="printme">print</a>
+
+    </div>
+
+</header>
+
+<h2 class="postingtitle">
+    <span class="postingtitletext">
+<span class="price">$1695</span> <span class="housing">/ 1br - </span><span id="titletextonly">At the side of Crown Heights awaits an undiscovered jewel!!!!!!!!!!!!!</span><small> (Sterling Pl / Crown Heights / Weeksville)</small>    </span>
+</h2>
+<section class="userbody">
+    <figure class="iw multiimage">
+    <div class="gallery">
+        <span class="slider-back arrow">&lt;</span>
+        <span class="slider-info">image 1 of 11</span>
+        <span class="slider-forward arrow">&gt;</span>
+
+
+    </div>
+        <script type="text/javascript"><!--
+--></script>
+
+</figure>
+
+
+    <div class="mapAndAttrs">
+<div class="mapbox">
+    <div id="map" class="viewposting" data-latitude="40.671299" data-longitude="-73.927693" data-accuracy="10"></div>
+    <div class="mapaddress">1540 Sterling Pl</div>
+    <p class="mapaddress">
+        <small>
+        (<a target="_blank" href="https://www.google.com/maps/preview/@40.671299,-73.927693,16z">google map</a>)
+        </small>
+    </p>
+</div>
+
+    <p class="attrgroup">
+
+
+
+            <span class="shared-line-bubble"><b>1BR</b> / <b>1Ba</b></span>
+
+
+
+
+            <span class="housing_movein_now property_date shared-line-bubble" data-date="2019-12-01" data-today_msg="available now">available dec 1</span>
+
+    </p>
+    <p class="attrgroup">
+
+
+
+            <span>application fee details: <b>$20 credit app</b></span>
+            <br>
+
+
+
+
+            <span>apartment</span>
+            <br>
+
+    </p>
+    </div>
+
+    <section id="postingbody">
+        <div class="print-information print-qrcode-container">
+            <p class="print-qrcode-label">QR Code Link to This Post</p>
+            <div class="print-qrcode" data-location="https://newyork.craigslist.org/brk/apa/d/brooklyn-at-the-side-of-crown-heights/7030152301.html"></div>
+        </div>
+At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly renovated apartment is waiting for you!<br>
+ <br>
+*New modern kitchen with stainless steel appliances<br>
+*Kitchen living room open concept<br>
+*New gorgeous tiled bath<br>
+*New flooring throughout the apartment<br>
+*Abundant sunlight through the large windows<br>
+*Great closet space<br>
+*State of the art surveillance system<br>
+*Very safe, quiet &amp; clean building <br>
+*Heat and Hot water included <br>
+*No pets<br>
+<br>
+Good credit and income to qualify. Guarantors welcome.<br>
+For more information or to schedule a viewing please call or text me at 201-297-6655<br>
+<br>
+    </section>
+
+<ul class="notices">
+            <li>do NOT contact me with unsolicited services or offers</li>
+</ul>
+
+    <div class="postinginfos">
+            <p class="postinginfo">post id: 7030152301</p>
+                <p class="postinginfo reveal">posted: <time class="date timeago" datetime="2019-12-01T13:04:39-0500">2019-12-01 13:04</time></p>
+
+
+               <p class="postinginfo">
+                   <a href="https://accounts.craigslist.org/eaf?postingID=7030152301&amp;token=U2FsdGVkX18xNzkxNTE3OZajN96iJGZ_hc8PBiLJgwQvhfUutvGRFScGE23YqG6Y" class="email-friend">email to friend</a>
+               </p>
+        <p class="postinginfo">
+              <a class="bestof-link" data-flag="9" href="https://post.craigslist.org/flag?flagCode=9&amp;postingID=7030152301" title="nominate for best-of-CL">
+                <span class="bestof-icon">&hearts; </span><span class="bestof-text">best of</span>
+              </a> <sup>[<a href="https://www.craigslist.org/about/best-of-craigslist">?</a>]</sup>
+        </p>
+
+    </div>
+
+    <div class="print-information print-pics"></div>
+
+</section>
+
+<div class="psa-box">
+</div>
+
+<div class="avoid-scams">
+<aside class="tsb">
+    Please flag
+    <a href="https://www.craigslist.org/about/FHA">discriminatory housing ads</a>
+</aside>
+
+<aside class="tsb">
+    <a href="https://www.craigslist.org/about/scams">Avoid scams, deal locally!</a>
+
+    <em>DO NOT wire funds (e.g. Western Union)</em>, or buy/rent sight unseen
+</aside>
+</div>
+
+        </section>
+<footer>
+    <ul class="clfooter">
+        <li>&copy;  <span class="desktop">craigslist</span><span class="mobile">CL</span></li>
+        <li><a href="https://www.craigslist.org/about/help/">help</a></li>
+        <li><a href="https://www.craigslist.org/about/scams">safety</a></li>
+        <li class="desktop"><a href="https://www.craigslist.org/about/privacy.policy">privacy</a></li>
+        <li class="desktop"><a href="https://forums.craigslist.org/?forumID=8">feedback</a></li>
+        <li class="desktop"><a href="https://www.craigslist.org/about/craigslist_is_hiring">cl jobs</a></li>
+        <li><a href="//www.craigslist.org/about/terms.of.use.en-us">terms</a><sup class="neu">new</sup></li>
+        <li><a href="https://www.craigslist.org/about/">about</a></li>
+        <li class="fsel desktop linklike" data-mode="mobile">mobile</li>
+        <li class="fsel mobile linklike" data-mode="regular">desktop</li>
+    </ul>
+</footer>
+    </section>
+
+
+        <script type="text/javascript"><!--
+var countOfTotalText = "image {count} of {total}";
+var imageConfig = {"1":{"hostname":"https://images.craigslist.org","sizes":["50x50c","300x300","600x450","1200x900"]},"0":{"hostname":"https://images.craigslist.org","sizes":["50x50c","300x300","600x450"]},"2":{"hostname":"https://images.craigslist.org","sizes":["50x50c","300x300","600x450","1200x900"]}};
+var maptileBaseUrl = "//map{s}.craigslist.org/t09/{z}/{x}/{y}.png";
+var pID = 7030152301;
+--></script>
+
+
+                <script>
+                try {
+                    if (
+                        !/\/\/.+\.craigslist\.org\/about\//.test(window.location.href)
+                        &&
+                        (!window.addEventListener || JSON.parse(JSON.stringify('x')) !== 'x')
+                    ) {
+                        throw "unsupported browser";
+                    }
+                } catch (e) {
+                    function cleanup() {
+                        document.body.innerHTML = '<div id="cl-unsupported-browser" style="margin:1em;font-size:150%;text-align:center;">We have detected you are using a browser that is missing critical features.<br><br>Please visit craigslist from a modern browser.</div>';
+                        document.body.style = "display:block";
+                    }
+
+                    try {
+                        document.body.style = "display:none";
+                    } catch (e) {
+                    }
+                    window.onload = cleanup;
+                    window.clUnsupportedBrowser = true;
+                }
+                </script>
+            <script src="//www.craigslist.org/js/general-concat.min.js?v=465a7dfa244af27ef2e11cc4f6c861aa" type="text/javascript" ></script>
+
+    <script src="//www.craigslist.org/js/leaflet-concat.min.js?v=e7a0a603160389eb711fc27bba8a20d9" type="text/javascript" ></script>
+
+<script src="//www.craigslist.org/js/postings-concat.min.js?v=50246caae35394381230131c050ac7f6" type="text/javascript" ></script>
+</body>
+</html>

--- a/refresh_apartment/sample-response/craigslist-url-normal.html
+++ b/refresh_apartment/sample-response/craigslist-url-normal.html
@@ -1,0 +1,427 @@
+
+<!DOCTYPE html>
+<html class="no-js">
+<head>
+<title>At the side of Crown Heights awaits an undiscovered jewel!!!!!!!!!!!!! - apts/housing for rent - apartment rent</title>
+    	<link rel="canonical" href="https://newyork.craigslist.org/brk/apa/d/brooklyn-at-the-side-of-crown-heights/7030152301.html">
+	<meta name="description" content="At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly renovated apartment is...">
+	<meta name="geo.placename" content="Brooklyn">
+	<meta name="geo.position" content="40.671299;-73.927693">
+	<meta name="geo.region" content="US-NY">
+	<meta name="robots" content="noarchive,nofollow,unavailable_after: 31-Dec-19 13:04:39 EST">
+	<meta name="twitter:card" content="preview">
+	<meta property="og:description" content="At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly renovated apartment is...">
+	<meta property="og:image" content="https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg">
+	<meta property="og:site_name" content="craigslist">
+	<meta property="og:title" content="At the side of Crown Heights awaits an undiscovered jewel!!!!!!!!!!!!!">
+	<meta property="og:type" content="article">
+	<meta property="og:url" content="https://newyork.craigslist.org/brk/apa/d/brooklyn-at-the-side-of-crown-heights/7030152301.html">
+<meta name="viewport" content="width=device-width,initial-scale=1"><link type="text/css" rel="stylesheet" media="all" href="//www.craigslist.org/styles/cl.css?v=1c8b9f6ba76c1ce6e888ec5c48118861"><link type="text/css" rel="stylesheet" media="all" href="//www.craigslist.org/styles/postings.css?v=8e8653ebb6d18c400a76f7c352499623">    <link type="text/css" rel="stylesheet" media="all" href="//www.craigslist.org/styles/leaflet.css?v=33e3dd14c7deed955c83b6927c5e1f07">
+</head>
+
+<body class="posting">
+<script type="text/javascript"><!--
+    function C(k){return(document.cookie.match('(^|; )'+k+'=([^;]*)')||0)[2]}
+    var pagetype, pagemode;
+    (function(){
+        var h = document.documentElement;
+        h.className = h.className.replace('no-js', 'js');
+        var b = document.body;
+        var bodyClassList = b.className.split(/\s+/);;
+        pagetype = bodyClassList[0]; // dangerous assumption
+        var fmt = C('cl_fmt');
+        if ( fmt === 'regular' || fmt === 'mobile' ) {
+            pagemode = fmt;
+        } else if (screen.width <= 480) {
+            pagemode = 'mobile';
+        } else {
+            pagemode = 'regular';
+        }
+        pagemode = pagemode === 'mobile' ? 'mobile' : 'desktop';
+        bodyClassList.push(pagemode);
+        if (C('hidesearch') === '1' && pagemode !== 'mobile') {
+            bodyClassList.push('hide-search');
+        }
+        var width = window.innerWidth || document.documentElement.clientWidth;
+        if (width > 1000) { bodyClassList.push('w1024'); }
+        if (typeof window.sectionBase !== 'undefined') {
+            var mode = (decodeURIComponent(C('cl_tocmode') || '').match(new RegExp(window.sectionBase + ':([^,]+)', 'i')) || {})[1] || window.defaultView;
+            if (mode) {
+                bodyClassList.push(mode);
+            }
+        }
+        b.className = bodyClassList.join(' ');
+    }());
+--></script>
+
+    <section class="page-container">
+        <div class="bglogo"></div>
+<header class="global-header wide">
+   <a class="header-logo" name="logoLink" href="/">CL</a>
+
+    <nav class="breadcrumbs-container">
+
+<ul class="breadcrumbs">
+        <li class="crumb area">
+            <p>
+                    <a href="/">new york</a>
+
+                    <span class="breadcrumb-arrow">&gt;</span>
+            </p>
+        </li>
+
+        <li class="crumb subarea">
+            <p>
+                    <a href="/brk/">brooklyn</a>
+                    <span class="breadcrumb-arrow">&gt;</span>
+            </p>
+        </li>
+
+        <li class="crumb section">
+            <p>
+                    <a href="/search/brk/hhh">housing</a>
+
+                    <span class="breadcrumb-arrow">&gt;</span>
+            </p>
+        </li>
+
+        <li class="crumb category">
+            <p>
+                <a href="/search/brk/apa">apts/housing for rent</a>
+
+            </p>
+        </li>
+
+</ul>
+    </nav>
+
+<div class="userlinks">
+    <ul class="user-actions">
+        <li class="user post">
+            <a href="https://post.craigslist.org/c/nyc">post</a>
+        </li>
+        <li class="user account">
+            <a href="https://accounts.craigslist.org/login/home">account</a>
+        </li>
+    </ul>
+    <ul class="user-favs-discards">
+        <li class="user">
+            <div class="favorites">
+                <a href="#" class="favlink"><span class="icon icon-star fav" aria-hidden="true"></span><span class="fav-number"></span><span class="fav-label"> favorites</span></a>
+            </div>
+        </li>
+        <li class="user discards">
+          <form class="unfavform js-only" method="POST" action="/favorites">
+            <div class="to-banish-page">
+              <input type="hidden" class="lastLink" name="lastLink" value="/brk/apa/7030152301.html">
+              <input type="hidden" class="lastTitle" name="lastTitle" value="At the side of Crown Heights awaits an undiscovered jewel!!!!!!!!!!!!!">
+              <input type="hidden" class="unfaves" name="fl">
+              <input type="hidden" name="uf" value="1">
+              <a href="#" class="to-banish-page-link">
+                <span class="icon icon-trash red" aria-hidden="true"></span>
+                <span class="banished_count"></span>
+                <span class="discards-label"> hidden</span>
+              </a>
+            </div>
+          </form>
+        </li>
+    </ul>
+</div>
+
+</header>
+<header class="global-header narrow">
+   <a class="header-logo" href="/">CL</a>
+    <nav class="breadcrumbs-container">
+
+<ul class="breadcrumbs">
+
+
+brooklyn            &gt;
+
+apts/housing for rent
+
+</ul>
+
+
+    </nav>
+    <span class="linklike show-wide-header">...</span>
+</header>
+        <section class="body">
+<header class="dateReplyBar">
+    <div class="prevnext-sec">
+        <div class="prevnext js-only">
+    <a class="prev">&#9664;  prev </a>
+    <a class="backup" title="back to search">&#9650;</a>
+    <a class="next"> next &#9654; </a>
+</div>
+
+    </div>
+
+    <div class="reply-button-row">
+    <div class="actions-combo">
+    <button role="button" class="reply-button js-only" data-href="/__SERVICE_ID__/nyc/apa/7030152301">
+      reply
+    </button>
+
+      <div class="reply-info js-only"></div>
+    <div class="fave-unfave action">
+        <div class="fave" role="button"  title="add to favorites">
+            <div class="icon icon-star" aria-hidden="true"></div>
+            <div class="action-label">favorite</div>
+        </div>
+        <div class="unfave" role="button" title="remove from favorites">
+            <div class="icon icon-star fav" aria-hidden="true"></div>
+            <div class="action-label">favorite</div>
+        </div>
+    </div>
+<div class="banish-unbanish action">
+  <div class="banish" role="button"  title="hide this posting">
+    <div class="icon icon-trash" aria-hidden="true"></div>
+    <div class="action-label">hide</div>
+  </div>
+  <div class="unbanish" role="button"  title="restore this posting">
+    <div class="icon icon-trash red" aria-hidden="true"></div>
+    <div class="action-label">unhide</div>
+  </div>
+</div>
+    <div class="flag-action action">
+        <div class="flag" data-flag="28" role="button" title="flag as prohibited / spam / miscategorized" >
+            <div class="flagIcon" aria-hidden="true">
+                <span class="white-flag">&#9872</span>
+                <span class="black-flag">&#9873</span>
+            </div>
+            <div class="action-label">
+                flag
+            </div>
+        </div>
+        <div class="unflag">
+            <div class="flagIcon" aria-hidden="true">&#9873</div>
+            <a class="action-label" href="https://www.craigslist.org/about/help/flags_and_community_moderation" title="thanks for flagging!">
+                flagged
+            </a>
+        </div>
+    </div>
+    </div>
+
+            <p id="display-date" class="postinginfo reveal">
+                    Posted
+                    <time class="date timeago" datetime="2019-12-01T13:04:39-0500">
+                        2019-12-01 13:04
+                    </time>
+            </p>
+
+            <p class="print-information print-contact">
+                Contact Information: <span class="print-email"></span> <span class="print-phone"></span>
+            </p>
+            <a href="#" id="printme">print</a>
+
+    </div>
+
+</header>
+
+<h2 class="postingtitle">
+    <span class="postingtitletext">
+<span class="price">$1695</span> <span class="housing">/ 1br - </span><span id="titletextonly">At the side of Crown Heights awaits an undiscovered jewel!!!!!!!!!!!!!</span><small> (Sterling Pl / Crown Heights / Weeksville)</small>    </span>
+</h2>
+<section class="userbody">
+    <figure class="iw multiimage">
+    <div class="gallery">
+        <span class="slider-back arrow">&lt;</span>
+        <span class="slider-info">image 1 of 11</span>
+        <span class="slider-forward arrow">&gt;</span>
+
+        <div class="swipe">
+            <div class="swipe-wrap">
+                <div id="1_image_2JxY7yF7CiN" data-imgid="2JxY7yF7CiN" class="slide first visible">
+                    <img src="https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg" title="1" alt="1">
+                </div>
+                <div id="2_image_kLnDTCuX0n3" data-imgid="kLnDTCuX0n3" class="slide">
+                </div>
+                <div id="3_image_6cBvpsChesd" data-imgid="6cBvpsChesd" class="slide">
+                </div>
+                <div id="4_image_kwC30PtSw8A" data-imgid="kwC30PtSw8A" class="slide">
+                </div>
+                <div id="5_image_hQyjtD6axnH" data-imgid="hQyjtD6axnH" class="slide">
+                </div>
+                <div id="6_image_kLnDTCuX0n3" data-imgid="kLnDTCuX0n3" class="slide">
+                </div>
+                <div id="7_image_2csoBB7ipC2" data-imgid="2csoBB7ipC2" class="slide">
+                </div>
+                <div id="8_image_NSNZLRfqMP" data-imgid="NSNZLRfqMP" class="slide">
+                </div>
+                <div id="9_image_eJaKO7kUClc" data-imgid="eJaKO7kUClc" class="slide">
+                </div>
+                <div id="10_image_9Mk6G5ftRQl" data-imgid="9Mk6G5ftRQl" class="slide">
+                </div>
+                <div id="11_image_7DX6qw3liZd" data-imgid="7DX6qw3liZd" class="slide">
+                </div>
+            </div>
+        </div>
+    </div>
+    <div id="thumbs"><a id="1_thumb_2JxY7yF7CiN" class="thumb" data-imgid="2JxY7yF7CiN" href="https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg" title="1"><img src="https://images.craigslist.org/00H0H_2JxY7yF7CiN_50x50c.jpg" class="selected" alt="1"></a><a id="2_thumb_kLnDTCuX0n3" class="thumb" data-imgid="kLnDTCuX0n3" href="https://images.craigslist.org/00t0t_kLnDTCuX0n3_600x450.jpg" title="2"><img src="https://images.craigslist.org/00t0t_kLnDTCuX0n3_50x50c.jpg" alt="2"></a><a id="3_thumb_6cBvpsChesd" class="thumb" data-imgid="6cBvpsChesd" href="https://images.craigslist.org/01111_6cBvpsChesd_600x450.jpg" title="3"><img src="https://images.craigslist.org/01111_6cBvpsChesd_50x50c.jpg" alt="3"></a><a id="4_thumb_kwC30PtSw8A" class="thumb" data-imgid="kwC30PtSw8A" href="https://images.craigslist.org/00m0m_kwC30PtSw8A_600x450.jpg" title="4"><img src="https://images.craigslist.org/00m0m_kwC30PtSw8A_50x50c.jpg" alt="4"></a><a id="5_thumb_hQyjtD6axnH" class="thumb" data-imgid="hQyjtD6axnH" href="https://images.craigslist.org/01515_hQyjtD6axnH_600x450.jpg" title="5"><img src="https://images.craigslist.org/01515_hQyjtD6axnH_50x50c.jpg" alt="5"></a><a id="6_thumb_kLnDTCuX0n3" class="thumb" data-imgid="kLnDTCuX0n3" href="https://images.craigslist.org/00t0t_kLnDTCuX0n3_600x450.jpg" title="6"><img src="https://images.craigslist.org/00t0t_kLnDTCuX0n3_50x50c.jpg" alt="6"></a><a id="7_thumb_2csoBB7ipC2" class="thumb" data-imgid="2csoBB7ipC2" href="https://images.craigslist.org/00o0o_2csoBB7ipC2_600x450.jpg" title="7"><img src="https://images.craigslist.org/00o0o_2csoBB7ipC2_50x50c.jpg" alt="7"></a><a id="8_thumb_NSNZLRfqMP" class="thumb" data-imgid="NSNZLRfqMP" href="https://images.craigslist.org/00D0D_NSNZLRfqMP_600x450.jpg" title="8"><img src="https://images.craigslist.org/00D0D_NSNZLRfqMP_50x50c.jpg" alt="8"></a><a id="9_thumb_eJaKO7kUClc" class="thumb" data-imgid="eJaKO7kUClc" href="https://images.craigslist.org/00s0s_eJaKO7kUClc_600x450.jpg" title="9"><img src="https://images.craigslist.org/00s0s_eJaKO7kUClc_50x50c.jpg" alt="9"></a><a id="10_thumb_9Mk6G5ftRQl" class="thumb" data-imgid="9Mk6G5ftRQl" href="https://images.craigslist.org/00p0p_9Mk6G5ftRQl_600x450.jpg" title="10"><img src="https://images.craigslist.org/00p0p_9Mk6G5ftRQl_50x50c.jpg" alt="10"></a><a id="11_thumb_7DX6qw3liZd" class="thumb" data-imgid="7DX6qw3liZd" href="https://images.craigslist.org/01414_7DX6qw3liZd_600x450.jpg" title="11"><img src="https://images.craigslist.org/01414_7DX6qw3liZd_50x50c.jpg" alt="11"></a></div>
+
+        <script type="text/javascript"><!--
+var imgList = [{"shortid":"2JxY7yF7CiN","url":"https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg","thumb":"https://images.craigslist.org/00H0H_2JxY7yF7CiN_50x50c.jpg","imgid":"1:00H0H_2JxY7yF7CiN"},{"shortid":"kLnDTCuX0n3","url":"https://images.craigslist.org/00t0t_kLnDTCuX0n3_600x450.jpg","thumb":"https://images.craigslist.org/00t0t_kLnDTCuX0n3_50x50c.jpg","imgid":"1:00t0t_kLnDTCuX0n3"},{"shortid":"6cBvpsChesd","url":"https://images.craigslist.org/01111_6cBvpsChesd_600x450.jpg","thumb":"https://images.craigslist.org/01111_6cBvpsChesd_50x50c.jpg","imgid":"1:01111_6cBvpsChesd"},{"shortid":"kwC30PtSw8A","url":"https://images.craigslist.org/00m0m_kwC30PtSw8A_600x450.jpg","thumb":"https://images.craigslist.org/00m0m_kwC30PtSw8A_50x50c.jpg","imgid":"1:00m0m_kwC30PtSw8A"},{"shortid":"hQyjtD6axnH","url":"https://images.craigslist.org/01515_hQyjtD6axnH_600x450.jpg","thumb":"https://images.craigslist.org/01515_hQyjtD6axnH_50x50c.jpg","imgid":"1:01515_hQyjtD6axnH"},{"shortid":"kLnDTCuX0n3","url":"https://images.craigslist.org/00t0t_kLnDTCuX0n3_600x450.jpg","thumb":"https://images.craigslist.org/00t0t_kLnDTCuX0n3_50x50c.jpg","imgid":"1:00t0t_kLnDTCuX0n3"},{"shortid":"2csoBB7ipC2","url":"https://images.craigslist.org/00o0o_2csoBB7ipC2_600x450.jpg","thumb":"https://images.craigslist.org/00o0o_2csoBB7ipC2_50x50c.jpg","imgid":"1:00o0o_2csoBB7ipC2"},{"shortid":"NSNZLRfqMP","url":"https://images.craigslist.org/00D0D_NSNZLRfqMP_600x450.jpg","thumb":"https://images.craigslist.org/00D0D_NSNZLRfqMP_50x50c.jpg","imgid":"1:00D0D_NSNZLRfqMP"},{"shortid":"eJaKO7kUClc","url":"https://images.craigslist.org/00s0s_eJaKO7kUClc_600x450.jpg","thumb":"https://images.craigslist.org/00s0s_eJaKO7kUClc_50x50c.jpg","imgid":"1:00s0s_eJaKO7kUClc"},{"shortid":"9Mk6G5ftRQl","url":"https://images.craigslist.org/00p0p_9Mk6G5ftRQl_600x450.jpg","thumb":"https://images.craigslist.org/00p0p_9Mk6G5ftRQl_50x50c.jpg","imgid":"1:00p0p_9Mk6G5ftRQl"},{"shortid":"7DX6qw3liZd","url":"https://images.craigslist.org/01414_7DX6qw3liZd_600x450.jpg","thumb":"https://images.craigslist.org/01414_7DX6qw3liZd_50x50c.jpg","imgid":"1:01414_7DX6qw3liZd"}];
+--></script>
+
+</figure>
+
+
+    <div class="mapAndAttrs">
+<div class="mapbox">
+    <div id="map" class="viewposting" data-latitude="40.671299" data-longitude="-73.927693" data-accuracy="10"></div>
+    <div class="mapaddress">1540 Sterling Pl</div>
+    <p class="mapaddress">
+        <small>
+        (<a target="_blank" href="https://www.google.com/maps/preview/@40.671299,-73.927693,16z">google map</a>)
+        </small>
+    </p>
+</div>
+
+    <p class="attrgroup">
+
+
+
+            <span class="shared-line-bubble"><b>1BR</b> / <b>1Ba</b></span>
+
+
+
+
+            <span class="housing_movein_now property_date shared-line-bubble" data-date="2019-12-01" data-today_msg="available now">available dec 1</span>
+
+    </p>
+    <p class="attrgroup">
+
+
+
+            <span>application fee details: <b>$20 credit app</b></span>
+            <br>
+
+
+
+
+            <span>apartment</span>
+            <br>
+
+    </p>
+    </div>
+
+    <section id="postingbody">
+        <div class="print-information print-qrcode-container">
+            <p class="print-qrcode-label">QR Code Link to This Post</p>
+            <div class="print-qrcode" data-location="https://newyork.craigslist.org/brk/apa/d/brooklyn-at-the-side-of-crown-heights/7030152301.html"></div>
+        </div>
+At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly renovated apartment is waiting for you!<br>
+ <br>
+*New modern kitchen with stainless steel appliances<br>
+*Kitchen living room open concept<br>
+*New gorgeous tiled bath<br>
+*New flooring throughout the apartment<br>
+*Abundant sunlight through the large windows<br>
+*Great closet space<br>
+*State of the art surveillance system<br>
+*Very safe, quiet &amp; clean building <br>
+*Heat and Hot water included <br>
+*No pets<br>
+<br>
+Good credit and income to qualify. Guarantors welcome.<br>
+For more information or to schedule a viewing please call or text me at 201-297-6655<br>
+<br>
+    </section>
+
+<ul class="notices">
+            <li>do NOT contact me with unsolicited services or offers</li>
+</ul>
+
+    <div class="postinginfos">
+            <p class="postinginfo">post id: 7030152301</p>
+                <p class="postinginfo reveal">posted: <time class="date timeago" datetime="2019-12-01T13:04:39-0500">2019-12-01 13:04</time></p>
+
+
+               <p class="postinginfo">
+                   <a href="https://accounts.craigslist.org/eaf?postingID=7030152301&amp;token=U2FsdGVkX18xNzkxNTE3OZajN96iJGZ_hc8PBiLJgwQvhfUutvGRFScGE23YqG6Y" class="email-friend">email to friend</a>
+               </p>
+        <p class="postinginfo">
+              <a class="bestof-link" data-flag="9" href="https://post.craigslist.org/flag?flagCode=9&amp;postingID=7030152301" title="nominate for best-of-CL">
+                <span class="bestof-icon">&hearts; </span><span class="bestof-text">best of</span>
+              </a> <sup>[<a href="https://www.craigslist.org/about/best-of-craigslist">?</a>]</sup>
+        </p>
+
+    </div>
+
+    <div class="print-information print-pics"></div>
+
+</section>
+
+<div class="psa-box">
+</div>
+
+<div class="avoid-scams">
+<aside class="tsb">
+    Please flag
+    <a href="https://www.craigslist.org/about/FHA">discriminatory housing ads</a>
+</aside>
+
+<aside class="tsb">
+    <a href="https://www.craigslist.org/about/scams">Avoid scams, deal locally!</a>
+
+    <em>DO NOT wire funds (e.g. Western Union)</em>, or buy/rent sight unseen
+</aside>
+</div>
+
+        </section>
+<footer>
+    <ul class="clfooter">
+        <li>&copy;  <span class="desktop">craigslist</span><span class="mobile">CL</span></li>
+        <li><a href="https://www.craigslist.org/about/help/">help</a></li>
+        <li><a href="https://www.craigslist.org/about/scams">safety</a></li>
+        <li class="desktop"><a href="https://www.craigslist.org/about/privacy.policy">privacy</a></li>
+        <li class="desktop"><a href="https://forums.craigslist.org/?forumID=8">feedback</a></li>
+        <li class="desktop"><a href="https://www.craigslist.org/about/craigslist_is_hiring">cl jobs</a></li>
+        <li><a href="//www.craigslist.org/about/terms.of.use.en-us">terms</a><sup class="neu">new</sup></li>
+        <li><a href="https://www.craigslist.org/about/">about</a></li>
+        <li class="fsel desktop linklike" data-mode="mobile">mobile</li>
+        <li class="fsel mobile linklike" data-mode="regular">desktop</li>
+    </ul>
+</footer>
+    </section>
+
+
+        <script type="text/javascript"><!--
+var countOfTotalText = "image {count} of {total}";
+var imageConfig = {"1":{"hostname":"https://images.craigslist.org","sizes":["50x50c","300x300","600x450","1200x900"]},"0":{"hostname":"https://images.craigslist.org","sizes":["50x50c","300x300","600x450"]},"2":{"hostname":"https://images.craigslist.org","sizes":["50x50c","300x300","600x450","1200x900"]}};
+var maptileBaseUrl = "//map{s}.craigslist.org/t09/{z}/{x}/{y}.png";
+var pID = 7030152301;
+--></script>
+
+
+                <script>
+                try {
+                    if (
+                        !/\/\/.+\.craigslist\.org\/about\//.test(window.location.href)
+                        &&
+                        (!window.addEventListener || JSON.parse(JSON.stringify('x')) !== 'x')
+                    ) {
+                        throw "unsupported browser";
+                    }
+                } catch (e) {
+                    function cleanup() {
+                        document.body.innerHTML = '<div id="cl-unsupported-browser" style="margin:1em;font-size:150%;text-align:center;">We have detected you are using a browser that is missing critical features.<br><br>Please visit craigslist from a modern browser.</div>';
+                        document.body.style = "display:block";
+                    }
+
+                    try {
+                        document.body.style = "display:none";
+                    } catch (e) {
+                    }
+                    window.onload = cleanup;
+                    window.clUnsupportedBrowser = true;
+                }
+                </script>
+            <script src="//www.craigslist.org/js/general-concat.min.js?v=465a7dfa244af27ef2e11cc4f6c861aa" type="text/javascript" ></script>
+
+    <script src="//www.craigslist.org/js/leaflet-concat.min.js?v=e7a0a603160389eb711fc27bba8a20d9" type="text/javascript" ></script>
+
+<script src="//www.craigslist.org/js/postings-concat.min.js?v=50246caae35394381230131c050ac7f6" type="text/javascript" ></script>
+</body>
+</html>

--- a/refresh_apartment/stub.py
+++ b/refresh_apartment/stub.py
@@ -1,0 +1,7 @@
+import os
+
+
+def get_craigslist_response(name) -> str:
+    filepath = os.path.join(os.path.dirname(__file__), "sample-response", name)
+    with open(filepath) as f:
+        return f.read()

--- a/refresh_apartment/tests.py
+++ b/refresh_apartment/tests.py
@@ -5,7 +5,6 @@ from .stub import get_craigslist_response
 from .views import get_img_url_and_description
 import os
 
-
 NORMAL_URL = "craigslist-url-normal.html"
 NO_PIC_URL = "craigslist-url-no-pic.html"
 NO_DESCRIPTION_URL = "craigslist-url-no-des.html"
@@ -21,7 +20,6 @@ class MockRequestResponse:
 @pytest.mark.celery(CELERY_BROKER_URL=os.environ["REDIS_URL"])
 @pytest.mark.celery(CELERY_RESULT_BACKEND=os.environ["REDIS_URL"])
 class AutoFetchTests(TestCase):
-
     def test_autofetch_redirect(self):
         """
         Test the redirect functionality
@@ -63,7 +61,9 @@ class AutoFetchTests(TestCase):
         self.assertEqual(response.status_code, 200)
         mockbckgrndfetch.delay.assert_called_with(city_list, 100)
 
-    @mock.patch("refresh_apartment.views.requests")  # all the requests in view is replaced with mock_requests here
+    @mock.patch(
+        "refresh_apartment.views.requests"
+    )  # all the requests in view is replaced with mock_requests here
     def test_normal_get_img_url_and_description(self, mock_requests):
         """
         :param mock_requests: mock the "requests" in your main code
@@ -77,11 +77,29 @@ class AutoFetchTests(TestCase):
         # It would mock the obj that it return with `return_value`.
         mock_requests.get = mock.MagicMock(return_value=mock_resp_obj)
 
-        url = "./sample-response/craigslist-url-normal.html"  # this url doesn't matter, could be whatever you like
+        url = (
+            "./sample-response/craigslist-url-normal.html"
+        )  # this url doesn't matter, could be whatever you like
         img_url, description = get_img_url_and_description(url)
 
-        self.assertEqual(img_url, "https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg")
-        self.assertEqual(description, "At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly renovated apartment is waiting for you!\n\n*New modern kitchen with stainless steel appliances\n*Kitchen living room open concept\n*New gorgeous tiled bath\n*New flooring throughout the apartment\n*Abundant sunlight through the large windows\n*Great closet space\n*State of the art surveillance system\n*Very safe, quiet & clean building \n*Heat and Hot water included \n*No pets\n\nGood credit and income to qualify. Guarantors welcome.\nFor more information or to schedule a viewing please call or text me at 201-297-6655")
+        self.assertEqual(
+            img_url, "https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg"
+        )
+        self.assertEqual(
+            description,
+            (
+                "At the side of Crown Heights awaits an undiscovered jewel. "
+                + "Located on Sterling Pl at Rochester Ave near the 3,4,A,C "
+                + "trains in a beautiful, quiet pre-war building, this newly "
+                + "renovated apartment is waiting for you!\n\n*New modern kitchen with stainless steel "
+                + "appliances\n*Kitchen living room open concept\n*New gorgeous tiled bath\n*New "
+                + "flooring throughout the apartment\n*Abundant sunlight through the large"
+                + " windows\n*Great closet space\n*State of the art surveillance system\n*Very safe, "
+                + "quiet & clean building \n*Heat and Hot water included \n*No pets\n\nGood credit and "
+                + "income to qualify. Guarantors welcome.\nFor more information or to schedule a viewing "
+                + "please call or text me at 201-297-6655",
+            ),
+        )
 
     @mock.patch("refresh_apartment.views.requests")
     def test_no_pic_get_img_url_and_description(self, mock_requests):
@@ -97,7 +115,21 @@ class AutoFetchTests(TestCase):
         img_url, description = get_img_url_and_description(url)
 
         self.assertEqual(img_url, "/static/img/no_img.png")
-        self.assertEqual(description, "At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly renovated apartment is waiting for you!\n\n*New modern kitchen with stainless steel appliances\n*Kitchen living room open concept\n*New gorgeous tiled bath\n*New flooring throughout the apartment\n*Abundant sunlight through the large windows\n*Great closet space\n*State of the art surveillance system\n*Very safe, quiet & clean building \n*Heat and Hot water included \n*No pets\n\nGood credit and income to qualify. Guarantors welcome.\nFor more information or to schedule a viewing please call or text me at 201-297-6655")
+        self.assertEqual(
+            description,
+            (
+                "At the side of Crown Heights awaits an undiscovered jewel. "
+                + "Located on Sterling Pl at Rochester Ave near the 3,4,A,C "
+                + "trains in a beautiful, quiet pre-war building, this newly "
+                + "renovated apartment is waiting for you!\n\n*New modern kitchen with stainless steel "
+                + "appliances\n*Kitchen living room open concept\n*New gorgeous tiled bath\n*New "
+                + "flooring throughout the apartment\n*Abundant sunlight through the large"
+                + " windows\n*Great closet space\n*State of the art surveillance system\n*Very safe, "
+                + "quiet & clean building \n*Heat and Hot water included \n*No pets\n\nGood credit and "
+                + "income to qualify. Guarantors welcome.\nFor more information or to schedule a viewing "
+                + "please call or text me at 201-297-6655",
+            ),
+        )
 
     @mock.patch("refresh_apartment.views.requests")
     def test_no_des_get_img_url_and_description(self, mock_requests):
@@ -112,7 +144,9 @@ class AutoFetchTests(TestCase):
         url = "whatever.html"
         img_url, description = get_img_url_and_description(url)
 
-        self.assertEqual(img_url, "https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg")
+        self.assertEqual(
+            img_url, "https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg"
+        )
         self.assertEqual(description, "DEFAULT DESCRIPTION")
 
     @mock.patch("refresh_apartment.views.requests")
@@ -130,5 +164,3 @@ class AutoFetchTests(TestCase):
 
         self.assertEqual(img_url, "/static/img/no_img.png")
         self.assertEqual(description, "DEFAULT DESCRIPTION")
-
-

--- a/refresh_apartment/tests.py
+++ b/refresh_apartment/tests.py
@@ -136,3 +136,19 @@ class AutoFetchTests(TestCase):
 
         self.assertEqual(img_url, "/static/img/no_img.png")
         self.assertEqual(description, "DEFAULT DESCRIPTION")
+
+    @mock.patch("refresh_apartment.views.requests")
+    def test_not_200_get_img_url_and_description(self, mock_requests):
+        """
+        :param mock_requests: mock the "requests" in your main code
+        """
+        craigslist_response_content = ""
+        mock_resp_obj = MockRequestResponse(404, craigslist_response_content)
+
+        mock_requests.get = mock.MagicMock(return_value=mock_resp_obj)
+
+        url = "whatever.html"
+        img_url, description = get_img_url_and_description(url)
+
+        self.assertEqual(img_url, "/static/img/no_img.png")
+        self.assertEqual(description, "DEFAULT DESCRIPTION")

--- a/refresh_apartment/tests.py
+++ b/refresh_apartment/tests.py
@@ -86,19 +86,14 @@ class AutoFetchTests(TestCase):
             img_url, "https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg"
         )
         self.assertEqual(
-            description,
-            (
-                "At the side of Crown Heights awaits an undiscovered jewel. "
-                + "Located on Sterling Pl at Rochester Ave near the 3,4,A,C "
-                + "trains in a beautiful, quiet pre-war building, this newly "
-                + "renovated apartment is waiting for you!\n\n*New modern kitchen with stainless steel "
-                + "appliances\n*Kitchen living room open concept\n*New gorgeous tiled bath\n*New "
-                + "flooring throughout the apartment\n*Abundant sunlight through the large"
-                + " windows\n*Great closet space\n*State of the art surveillance system\n*Very safe, "
-                + "quiet & clean building \n*Heat and Hot water included \n*No pets\n\nGood credit and "
-                + "income to qualify. Guarantors welcome.\nFor more information or to schedule a viewing "
-                + "please call or text me at 201-297-6655",
-            ),
+            description, "At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at "
+                         "Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly "
+                         "renovated apartment is waiting for you!\n\n*New modern kitchen with stainless steel "
+                         "appliances\n*Kitchen living room open concept\n*New gorgeous tiled bath\n*New flooring "
+                         "throughout the apartment\n*Abundant sunlight through the large windows\n*Great closet "
+                         "space\n*State of the art surveillance system\n*Very safe, quiet & clean building \n*Heat and "
+                         "Hot water included \n*No pets\n\nGood credit and income to qualify. Guarantors welcome.\nFor "
+                         "more information or to schedule a viewing please call or text me at 201-297-6655"
         )
 
     @mock.patch("refresh_apartment.views.requests")
@@ -116,19 +111,14 @@ class AutoFetchTests(TestCase):
 
         self.assertEqual(img_url, "/static/img/no_img.png")
         self.assertEqual(
-            description,
-            (
-                "At the side of Crown Heights awaits an undiscovered jewel. "
-                + "Located on Sterling Pl at Rochester Ave near the 3,4,A,C "
-                + "trains in a beautiful, quiet pre-war building, this newly "
-                + "renovated apartment is waiting for you!\n\n*New modern kitchen with stainless steel "
-                + "appliances\n*Kitchen living room open concept\n*New gorgeous tiled bath\n*New "
-                + "flooring throughout the apartment\n*Abundant sunlight through the large"
-                + " windows\n*Great closet space\n*State of the art surveillance system\n*Very safe, "
-                + "quiet & clean building \n*Heat and Hot water included \n*No pets\n\nGood credit and "
-                + "income to qualify. Guarantors welcome.\nFor more information or to schedule a viewing "
-                + "please call or text me at 201-297-6655",
-            ),
+            description, "At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at "
+                         "Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly "
+                         "renovated apartment is waiting for you!\n\n*New modern kitchen with stainless steel "
+                         "appliances\n*Kitchen living room open concept\n*New gorgeous tiled bath\n*New flooring "
+                         "throughout the apartment\n*Abundant sunlight through the large windows\n*Great closet "
+                         "space\n*State of the art surveillance system\n*Very safe, quiet & clean building \n*Heat and "
+                         "Hot water included \n*No pets\n\nGood credit and income to qualify. Guarantors welcome.\nFor "
+                         "more information or to schedule a viewing please call or text me at 201-297-6655"
         )
 
     @mock.patch("refresh_apartment.views.requests")

--- a/refresh_apartment/tests.py
+++ b/refresh_apartment/tests.py
@@ -85,16 +85,7 @@ class AutoFetchTests(TestCase):
         self.assertEqual(
             img_url, "https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg"
         )
-        self.assertEqual(
-            description, "At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at "
-                         "Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly "
-                         "renovated apartment is waiting for you!\n\n*New modern kitchen with stainless steel "
-                         "appliances\n*Kitchen living room open concept\n*New gorgeous tiled bath\n*New flooring "
-                         "throughout the apartment\n*Abundant sunlight through the large windows\n*Great closet "
-                         "space\n*State of the art surveillance system\n*Very safe, quiet & clean building \n*Heat and "
-                         "Hot water included \n*No pets\n\nGood credit and income to qualify. Guarantors welcome.\nFor "
-                         "more information or to schedule a viewing please call or text me at 201-297-6655"
-        )
+        self.assertNotEqual(description, "DEFAULT DESCRIPTION")
 
     @mock.patch("refresh_apartment.views.requests")
     def test_no_pic_get_img_url_and_description(self, mock_requests):
@@ -110,16 +101,7 @@ class AutoFetchTests(TestCase):
         img_url, description = get_img_url_and_description(url)
 
         self.assertEqual(img_url, "/static/img/no_img.png")
-        self.assertEqual(
-            description, "At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at "
-                         "Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly "
-                         "renovated apartment is waiting for you!\n\n*New modern kitchen with stainless steel "
-                         "appliances\n*Kitchen living room open concept\n*New gorgeous tiled bath\n*New flooring "
-                         "throughout the apartment\n*Abundant sunlight through the large windows\n*Great closet "
-                         "space\n*State of the art surveillance system\n*Very safe, quiet & clean building \n*Heat and "
-                         "Hot water included \n*No pets\n\nGood credit and income to qualify. Guarantors welcome.\nFor "
-                         "more information or to schedule a viewing please call or text me at 201-297-6655"
-        )
+        self.assertNotEqual(description, "DEFAULT DESCRIPTION")
 
     @mock.patch("refresh_apartment.views.requests")
     def test_no_des_get_img_url_and_description(self, mock_requests):

--- a/refresh_apartment/tests.py
+++ b/refresh_apartment/tests.py
@@ -1,14 +1,27 @@
 import pytest
 from django.test import TestCase
 from unittest import mock
+from .stub import get_craigslist_response
+from .views import get_img_url_and_description
 import os
 
-# Create your tests here.
+
+NORMAL_URL = "craigslist-url-normal.html"
+NO_PIC_URL = "craigslist-url-no-pic.html"
+NO_DESCRIPTION_URL = "craigslist-url-no-des.html"
+NO_PIC_NO_DESCRIPTION_URL = "craigslist-url-no-pic-no-des.html"
+
+
+class MockRequestResponse:
+    def __init__(self, status_code, content):
+        self.status_code = status_code
+        self.content = content
 
 
 @pytest.mark.celery(CELERY_BROKER_URL=os.environ["REDIS_URL"])
 @pytest.mark.celery(CELERY_RESULT_BACKEND=os.environ["REDIS_URL"])
 class AutoFetchTests(TestCase):
+
     def test_autofetch_redirect(self):
         """
         Test the redirect functionality
@@ -49,3 +62,73 @@ class AutoFetchTests(TestCase):
         city_list = []
         self.assertEqual(response.status_code, 200)
         mockbckgrndfetch.delay.assert_called_with(city_list, 100)
+
+    @mock.patch("refresh_apartment.views.requests")  # all the requests in view is replaced with mock_requests here
+    def test_normal_get_img_url_and_description(self, mock_requests):
+        """
+        :param mock_requests: mock the "requests" in your main code
+        """
+        # setup(mock) the object which requests.get(url) return
+        craigslist_response_content = get_craigslist_response(NORMAL_URL)
+        mock_resp_obj = MockRequestResponse(200, craigslist_response_content)
+
+        # The moment that the mock take into place
+        # When your test run the line "request.get" in your main code,
+        # It would mock the obj that it return with `return_value`.
+        mock_requests.get = mock.MagicMock(return_value=mock_resp_obj)
+
+        url = "./sample-response/craigslist-url-normal.html"  # this url doesn't matter, could be whatever you like
+        img_url, description = get_img_url_and_description(url)
+
+        self.assertEqual(img_url, "https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg")
+        self.assertEqual(description, "At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly renovated apartment is waiting for you!\n\n*New modern kitchen with stainless steel appliances\n*Kitchen living room open concept\n*New gorgeous tiled bath\n*New flooring throughout the apartment\n*Abundant sunlight through the large windows\n*Great closet space\n*State of the art surveillance system\n*Very safe, quiet & clean building \n*Heat and Hot water included \n*No pets\n\nGood credit and income to qualify. Guarantors welcome.\nFor more information or to schedule a viewing please call or text me at 201-297-6655")
+
+    @mock.patch("refresh_apartment.views.requests")
+    def test_no_pic_get_img_url_and_description(self, mock_requests):
+        """
+        :param mock_requests: mock the "requests" in your main code
+        """
+        craigslist_response_content = get_craigslist_response(NO_PIC_URL)
+        mock_resp_obj = MockRequestResponse(200, craigslist_response_content)
+
+        mock_requests.get = mock.MagicMock(return_value=mock_resp_obj)
+
+        url = "whatever.html"
+        img_url, description = get_img_url_and_description(url)
+
+        self.assertEqual(img_url, "/static/img/no_img.png")
+        self.assertEqual(description, "At the side of Crown Heights awaits an undiscovered jewel. Located on Sterling Pl at Rochester Ave near the 3,4,A,C trains in a beautiful, quiet pre-war building, this newly renovated apartment is waiting for you!\n\n*New modern kitchen with stainless steel appliances\n*Kitchen living room open concept\n*New gorgeous tiled bath\n*New flooring throughout the apartment\n*Abundant sunlight through the large windows\n*Great closet space\n*State of the art surveillance system\n*Very safe, quiet & clean building \n*Heat and Hot water included \n*No pets\n\nGood credit and income to qualify. Guarantors welcome.\nFor more information or to schedule a viewing please call or text me at 201-297-6655")
+
+    @mock.patch("refresh_apartment.views.requests")
+    def test_no_des_get_img_url_and_description(self, mock_requests):
+        """
+        :param mock_requests: mock the "requests" in your main code
+        """
+        craigslist_response_content = get_craigslist_response(NO_DESCRIPTION_URL)
+        mock_resp_obj = MockRequestResponse(200, craigslist_response_content)
+
+        mock_requests.get = mock.MagicMock(return_value=mock_resp_obj)
+
+        url = "whatever.html"
+        img_url, description = get_img_url_and_description(url)
+
+        self.assertEqual(img_url, "https://images.craigslist.org/00H0H_2JxY7yF7CiN_600x450.jpg")
+        self.assertEqual(description, "DEFAULT DESCRIPTION")
+
+    @mock.patch("refresh_apartment.views.requests")
+    def test_no_pic_no_des_get_img_url_and_description(self, mock_requests):
+        """
+        :param mock_requests: mock the "requests" in your main code
+        """
+        craigslist_response_content = get_craigslist_response(NO_PIC_NO_DESCRIPTION_URL)
+        mock_resp_obj = MockRequestResponse(200, craigslist_response_content)
+
+        mock_requests.get = mock.MagicMock(return_value=mock_resp_obj)
+
+        url = "whatever.html"
+        img_url, description = get_img_url_and_description(url)
+
+        self.assertEqual(img_url, "/static/img/no_img.png")
+        self.assertEqual(description, "DEFAULT DESCRIPTION")
+
+

--- a/refresh_apartment/views.py
+++ b/refresh_apartment/views.py
@@ -42,6 +42,7 @@ def autofetch(request):
 
     return render(request, "account.html")
 
+
 @shared_task
 def bckgrndfetch(city_list, limit):
 
@@ -189,9 +190,10 @@ def get_img_url_and_description(url):
         img_tag = soup.find_all("a", {"class": "thumb"})
 
         body = soup.find("section", id="postingbody")
-        body_text = (getattr(e, "text", e) for e in body
-                     if not getattr(e, "attrs", None))
-        description = ''.join(body_text).strip()
+        body_text = (
+            getattr(e, "text", e) for e in body if not getattr(e, "attrs", None)
+        )
+        description = "".join(body_text).strip()
 
         if len(img_tag) == 0 and description == "":
             return DEFAULT_IMG_URL, DEFAULT_DESCRIPTION

--- a/refresh_apartment/views.py
+++ b/refresh_apartment/views.py
@@ -1,3 +1,5 @@
+from bs4 import BeautifulSoup
+import requests
 from django.shortcuts import render
 from external.craigslist import fetch_craigslist_housing
 from external.googleapi.fetch import fetch_reverse_geocode
@@ -10,6 +12,8 @@ import googlemaps
 
 
 CITY_LIST = ["brx", "brk", "fct", "lgi", "mnh", "jsy", "que", "stn", "wch"]
+DEFAULT_IMG_URL = "/static/img/no_img.png"
+DEFAULT_DESCRIPTION = "DEFAULT DESCRIPTION"
 
 
 def autofetch(request):
@@ -37,7 +41,6 @@ def autofetch(request):
         bckgrndfetch.delay(list(city_list), int(limit))
 
     return render(request, "account.html")
-
 
 @shared_task
 def bckgrndfetch(city_list, limit):
@@ -68,13 +71,24 @@ def bckgrndfetch(city_list, limit):
             last_updated = r["last_updated"]
             bedrooms = r["bedrooms"]
 
+            image_url, description = DEFAULT_IMG_URL, DEFAULT_DESCRIPTION
+            try:
+                image_url, description = get_img_url_and_description(r["url"])
+            except requests.exceptions.ConnectionError:
+                pass
+
             if len(Apartment.objects.filter(c_id=c_id)) > 0:
 
                 apartment = Apartment.objects.get(c_id=c_id)
                 if apartment.last_modified != last_updated:
+
                     print(
                         f"city_name={city_name}: Found existing apartment for c_id = {c_id}, updating."
                     )
+
+                    apartment.image = image_url
+                    apartment.description = description
+
                     apartment.rent_price = price
                     apartment.number_of_bed = bedrooms
                     apartment.last_modified = last_updated
@@ -157,6 +171,8 @@ def bckgrndfetch(city_list, limit):
                 )
 
                 apartment.rent_price = price
+                apartment.image = image_url
+                apartment.description = description
                 apartment.number_of_bed = bedrooms
                 apartment.last_modified = last_updated
                 apartment.save()
@@ -164,3 +180,27 @@ def bckgrndfetch(city_list, limit):
         print(" Finish query\n")
 
     print(f"End at: {str(datetime.now())} \n")
+
+
+def get_img_url_and_description(url):
+    result = requests.get(url)
+    if result.status_code == 200:
+        soup = BeautifulSoup(result.content, "html.parser")
+        img_tag = soup.find_all("a", {"class": "thumb"})
+        img_url = img_tag[0].get("href")
+
+        body = soup.find("section", id="postingbody")
+        body_text = (getattr(e, "text", e) for e in body
+                     if not getattr(e, "attrs", None))
+        description = ''.join(body_text).strip()
+
+        if len(img_tag) == 0 and description == "":
+            return DEFAULT_IMG_URL, DEFAULT_DESCRIPTION
+        elif len(img_tag) == 0:
+            return DEFAULT_IMG_URL, description
+        elif description == "":
+            return img_url, DEFAULT_DESCRIPTION
+        else:
+            return img_url, description
+    else:
+        return DEFAULT_IMG_URL, DEFAULT_DESCRIPTION

--- a/refresh_apartment/views.py
+++ b/refresh_apartment/views.py
@@ -187,7 +187,6 @@ def get_img_url_and_description(url):
     if result.status_code == 200:
         soup = BeautifulSoup(result.content, "html.parser")
         img_tag = soup.find_all("a", {"class": "thumb"})
-        img_url = img_tag[0].get("href")
 
         body = soup.find("section", id="postingbody")
         body_text = (getattr(e, "text", e) for e in body
@@ -199,8 +198,8 @@ def get_img_url_and_description(url):
         elif len(img_tag) == 0:
             return DEFAULT_IMG_URL, description
         elif description == "":
-            return img_url, DEFAULT_DESCRIPTION
+            return img_tag[0].get("href"), DEFAULT_DESCRIPTION
         else:
-            return img_url, description
+            return img_tag[0].get("href"), description
     else:
         return DEFAULT_IMG_URL, DEFAULT_DESCRIPTION

--- a/refresh_apartment/views.py
+++ b/refresh_apartment/views.py
@@ -191,8 +191,10 @@ def get_img_url_and_description(url):
 
         body = soup.find("section", id="postingbody")
         body_text = (
-            getattr(e, "text", e) for e in body if not getattr(e, "attrs", None)
-        ) if body is not None else ""
+            (getattr(e, "text", e) for e in body if not getattr(e, "attrs", None))
+            if body is not None
+            else ""
+        )
         description = "".join(body_text).strip()
 
         if len(img_tag) == 0 and description == "":

--- a/refresh_apartment/views.py
+++ b/refresh_apartment/views.py
@@ -192,7 +192,7 @@ def get_img_url_and_description(url):
         body = soup.find("section", id="postingbody")
         body_text = (
             getattr(e, "text", e) for e in body if not getattr(e, "attrs", None)
-        )
+        ) if body is not None else ""
         description = "".join(body_text).strip()
 
         if len(img_tag) == 0 and description == "":

--- a/search/views.py
+++ b/search/views.py
@@ -100,7 +100,7 @@ def search(request):
                 matching_apartments[loc.id] = num_matches
                 for apt in matches:
                     if apt.image:
-                        thumbnails[loc.id] = apt.image.url
+                        thumbnails[loc.id] = apt.image
                         break
 
             search_data["matching_apartments"] = matching_apartments


### PR DESCRIPTION
This PR adds functionality in `refresh_apartment`:
- crawl image from the URL
- crawl description from the URL

And also fix the code of display image in `search.html` and `apartment.html`.

![image](https://user-images.githubusercontent.com/18141004/69981158-be4aa380-14ff-11ea-9866-503e31180f47.png)
![image](https://user-images.githubusercontent.com/18141004/69981188-ce628300-14ff-11ea-8d38-a2fa8f7c2d5e.png)
