### PR TITLE
Apartment Creation Redirect

### DIFF
--- a/location/templates/apartment_upload_confirmation.html
+++ b/location/templates/apartment_upload_confirmation.html
@@ -1,6 +1,0 @@
-{% extends 'base.html' %}
-{% load crispy_forms_tags %}
-
-{% block content %}
-    <p>Your apartment has been successfully uploaded. Click <a href="/">here</a> to go back to the homepage.</p>
-{% endblock %}

--- a/location/tests.py
+++ b/location/tests.py
@@ -202,7 +202,7 @@ class LocationViewTests(TestCase):
         }
 
         response = self.client.post(reverse("apartment_upload"), post_data)
-        self.assertRedirects(response, reverse("apartment_upload_confirmation"))
+        self.assertRedirects(response, reverse("apartment", kwargs={"pk": 7, "apk": 8}))
 
     @mock.patch("location.views.fetch_geocode", fetch_geocode_stub)
     @mock.patch("location.forms.fetch_geocode", fetch_geocode_stub)

--- a/location/urls.py
+++ b/location/urls.py
@@ -23,9 +23,4 @@ urlpatterns = [
     path("favlist", views.favlist, name="favlist"),
     path("<int:pk>/review", views.review, name="review"),
     path("apartment_upload", views.apartment_upload, name="apartment_upload"),
-    path(
-        "apartment_upload_confirmation",
-        views.apartment_upload_confirmation,
-        name="apartment_upload_confirmation",
-    ),
 ]

--- a/location/views.py
+++ b/location/views.py
@@ -153,7 +153,7 @@ def contact_landlord(request, pk, apk):
                 subject, message, sender_email, [landlord_email], fail_silently=False
             )
             messages.success(
-                request, "An email has been sent to the landlord!", extra_tags="email"
+                request, "An email has been sent to the landlord!", extra_tags="success"
             )
 
     return HttpResponseRedirect(reverse("apartment", kwargs={"pk": pk, "apk": apk}))
@@ -168,14 +168,14 @@ def favorites(request, pk):
         messages.success(
             request,
             "This apartment has been added to your favorites!",
-            extra_tags="apartment",
+            extra_tags="success",
         )
     else:
         user.favorites.remove(apartment)
         messages.success(
             request,
             "This apartment has been removed from your favorites!",
-            extra_tags="apartment",
+            extra_tags="success",
         )
     return HttpResponseRedirect(reverse("location", args=(pk,)))
 
@@ -262,17 +262,16 @@ def apartment_upload(request):
 
             apt.save()
 
-            # redirect to the confirmation page
-            return HttpResponseRedirect(reverse("apartment_upload_confirmation"))
-        else:
-            return render(request, "apartment_upload.html", {"form": form})
+            messages.success(
+                request, message="Successfully created Apartment!", extra_tags="success"
+            )
+
+            return HttpResponseRedirect(
+                reverse("apartment", kwargs={"pk": loc.id, "apk": apt.id})
+            )
 
     # if a GET (or any other method) we'll create a blank form
     else:
         form = ApartmentUploadForm()
 
     return render(request, "apartment_upload.html", {"form": form})
-
-
-def apartment_upload_confirmation(request):
-    return render(request, "apartment_upload_confirmation.html")

--- a/mainapp/templates/base.html
+++ b/mainapp/templates/base.html
@@ -3,12 +3,22 @@
 {% block body %}
 
 <div class="breadcrumbs">
-{% block breadcrumbs %}
-{% endblock %}
+    {% block breadcrumbs %}
+    {% endblock %}
 </div>
 
 <main role="main" class="container">
     <div class="container">
+
+        {% if messages %}
+            <div class="row justify-content-center">
+                {% for message in messages %}
+                    <div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %} col-sm-6">{{ message }}<button
+                            type="button" class="close" data-dismiss="alert" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button></div>
+                {% endfor %}
+            </div>
+        {% endif %}
         <div class="row justify-content-center">
             <div class="col center-container">
                 {% block content %}


### PR DESCRIPTION
Update the apartment creation redirect so that instead of displaying a very plain page, it just redirects to the created apartment and displays a success message.

This fixes testing day bug #286 .