### PR TITLE
added null check to suite number on apartment update form

### DIFF
--- a/location/forms.py
+++ b/location/forms.py
@@ -181,7 +181,7 @@ class ApartmentUpdateForm(forms.ModelForm):
         # access the passed in instance of the Apartment model to get its location
         location = self.instance.location
 
-        if suite_num.strip()[0] == "-":
+        if suite_num and suite_num.strip()[0] == "-":
             raise forms.ValidationError(
                 "You cannot submit an apartment with a negative Suite Number"
             )


### PR DESCRIPTION
Fixed an issue where update an apartment retrieved from craigslist (which often doesn't have a suite number) throws an exception.