### PR TITLE
added z-index

### DIFF
--- a/mainapp/templates/nav.html
+++ b/mainapp/templates/nav.html
@@ -77,7 +77,7 @@
     </header>
     {% if messages %}
     {% for message in messages %}
-        <div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %} col-sm-6 alert-top">{{ message }}<button
+        <div class="alert {% if message.tags %}alert-{{ message.tags }}{% endif %} col-sm-6 alert-top" style="z-index: 1000">{{ message }}<button
                 type="button" class="close" data-dismiss="alert" aria-label="Close"><span
                     aria-hidden="true">&times;</span></button></div>
     {% endfor %}


### PR DESCRIPTION
This fixes a bug where when the user is signing up for a new account. When the submit the signup form, the confirmation message displayed on the redirected page is behind the page header. This is also present when the user confirms their email address.

This PR just adds a high z-index to the messages div so it always displays on top.

How it looks after fix: 
![Screen Shot 2019-12-08 at 12 48 08 PM](https://user-images.githubusercontent.com/32490273/70393625-e895d880-19b9-11ea-8b74-c2689dcbd979.png)
