### PR TITLE
Neighborhood bug search

### DIFF
--- a/external/googleapi/g_utils.py
+++ b/external/googleapi/g_utils.py
@@ -40,6 +40,13 @@ def normalize_us_address(address) -> Optional[Address]:
             longitude=cache.longitude,
         )
 
+    if (
+        "ny" not in address.lower()
+        or "new york" not in address.lower()
+        or "newyork" not in address.lower()
+    ):
+        address += " ny"
+
     response_list = fetch_geocode(address, region="us")
 
     if not response_list:

--- a/external/googleapi/tests.py
+++ b/external/googleapi/tests.py
@@ -557,6 +557,7 @@ class GUtilsTests(TestCase):
         """
         search_string = "123 USA Street, Anytown, Anystate 00000"
         search_string_norm = " ".join(search_string.split()).lower()
+        search_string_norm += " ny"
         mock_fetch.return_value = None
 
         input = normalize_us_address(search_string)

--- a/review/tests.py
+++ b/review/tests.py
@@ -16,3 +16,11 @@ class ReviewModelTests(TestCase):
         l1 = Location.objects.create(state="NY")
         r1 = Review.objects.create(location=l1, user=s1, content="test_content")
         self.assertEqual(r1.content, "test_content")
+
+    def test_str_method(self):
+        user = SiteUser.objects.create_user(username="user")
+        loc = Location.objects.create(state="NY")
+        review = Review.objects.create(
+            location=loc, user=user, content="This is a review."
+        )
+        self.assertEqual(str(review), "user: This is a review.")

--- a/search/tests.py
+++ b/search/tests.py
@@ -302,7 +302,8 @@ class SearchQueryBuilderTests(TestCase):
     def test_build_query_locality_mismatch(self):
         """
         Tests the return value of build_search_query when
-        the address locality is in the original query
+        the address locality is in the original query but
+        the locality has spacing issues
         """
 
         addr = Address.from_dict(
@@ -337,7 +338,8 @@ class SearchQueryBuilderTests(TestCase):
     def test_build_query_locality_mismatch_no_state(self):
         """
         Tests the return value of build_search_query when
-        the address locality is in the original query
+        the address locality is in the original query but
+        the locality has spacing issues and there is no state
         """
 
         addr = Address.from_dict(

--- a/search/tests.py
+++ b/search/tests.py
@@ -323,7 +323,7 @@ class SearchQueryBuilderTests(TestCase):
             bed_num="",
         )
         query_result_dict = {
-            "address__iexact": "28-15 34th street",
+            "address__icontains": "28-15 34th street",
             "city__iexact": "Long Island City",
             "state__iexact": "NY",
             "zipcode": "11103",
@@ -358,7 +358,7 @@ class SearchQueryBuilderTests(TestCase):
             bed_num="",
         )
         query_result_dict = {
-            "address__iexact": "28-15 34th street",
+            "address__icontains": "28-15 34th street",
             "locality__iexact": "Queens",
             "state__iexact": "NY",
             "zipcode": "11103",
@@ -393,7 +393,7 @@ class SearchQueryBuilderTests(TestCase):
             bed_num="",
         )
         query_result_dict = {
-            "address__iexact": "28-15 34th street",
+            "address__icontains": "28-15 34th street",
             "city__iexact": "Long Island City",
             "state__iexact": "NY",
             "zipcode": "11103",
@@ -429,7 +429,7 @@ class SearchQueryBuilderTests(TestCase):
             bed_num="",
         )
         query_result_dict = {
-            "address__iexact": "28-15 34th street",
+            "address__icontains": "28-15 34th street",
             "city__iexact": "Long Island City",
             "state__iexact": "NY",
             "zipcode": "11103",
@@ -465,7 +465,7 @@ class SearchQueryBuilderTests(TestCase):
             bed_num="",
         )
         query_result_dict = {
-            "address__iexact": "28-15 34th street",
+            "address__icontains": "28-15 34th street",
             "city__iexact": "Long Island City",
             "state__iexact": "NY",
             "zipcode": "11103",
@@ -507,7 +507,7 @@ class SearchQueryBuilderTests(TestCase):
             bed_num="1",
         )
         query_result_dict = {
-            "address__iexact": "28-15 34th street",
+            "address__icontains": "28-15 34th street",
             "city__iexact": "Long Island City",
             "state__iexact": "NY",
             "zipcode": "11103",
@@ -549,7 +549,7 @@ class SearchQueryBuilderTests(TestCase):
             bed_num="1",
         )
         query_result_dict = {
-            "address__iexact": "28-15 34th street",
+            "address__icontains": "28-15 34th street",
             "city__iexact": "Long Island City",
             "state__iexact": "NY",
             "zipcode": "11103",
@@ -581,6 +581,73 @@ class SearchQueryBuilderTests(TestCase):
         )
         query_result_dict = {
             "city__iexact": "Bay Ridge",
+            "state__iexact": "NY",
+            "apartment_set__is_rented": False,
+        }
+        query_result_apa_dict = {"is_rented": False}
+
+        self.assertDictEqual(q_loc, query_result_dict)
+        self.assertDictEqual(q_apa, query_result_apa_dict)
+
+    def test_build_query_street_state(self):
+        """
+        test building the location query with only the street name
+        and state
+        """
+        addr = Address.from_dict(
+            {
+                "street": "Herkimer Street",
+                "zipcode": "",
+                "city": "Brooklyn",
+                "state": "NY",
+                "latitude": 0.0,
+                "longitude": 0.0,
+                "locality": "Brooklyn",
+            }
+        )
+
+        q_loc, q_apa = build_search_query(
+            address=addr,
+            orig_query="Herkimer Street, NY",
+            min_price="",
+            max_price="",
+            bed_num="",
+        )
+        query_result_dict = {
+            "address__icontains": "Herkimer Street",
+            "state__iexact": "NY",
+            "apartment_set__is_rented": False,
+        }
+        query_result_apa_dict = {"is_rented": False}
+
+        self.assertDictEqual(q_loc, query_result_dict)
+        self.assertDictEqual(q_apa, query_result_apa_dict)
+
+    def test_build_query_street_only(self):
+        """
+        test building the location query with only the street name
+        """
+        addr = Address.from_dict(
+            {
+                "street": "Herkimer Street",
+                "zipcode": "",
+                "city": "Brooklyn",
+                "state": "NY",
+                "latitude": 0.0,
+                "longitude": 0.0,
+                "locality": "Brooklyn",
+            }
+        )
+
+        q_loc, q_apa = build_search_query(
+            address=addr,
+            orig_query="Herkimer Street",
+            min_price="",
+            max_price="",
+            bed_num="",
+        )
+        query_result_dict = {
+            "address__icontains": "Herkimer Street",
             "state__iexact": "NY",
             "apartment_set__is_rented": False,
         }

--- a/search/tests.py
+++ b/search/tests.py
@@ -299,6 +299,76 @@ class SearchQueryBuilderTests(TestCase):
         self.assertDictEqual(q_loc, query_result_dict)
         self.assertDictEqual(q_apa, query_result_apa_dict)
 
+    def test_build_query_locality_mismatch(self):
+        """
+        Tests the return value of build_search_query when
+        the address locality is in the original query
+        """
+
+        addr = Address.from_dict(
+            {
+                "street": "",
+                "zipcode": "",
+                "city": "Staten Island",
+                "state": "NY",
+                "latitude": 40.6195067,
+                "longitude": -73.9859414,
+                "locality": "Staten Island",
+            }
+        )
+
+        q_loc, q_apa = build_search_query(
+            address=addr,
+            orig_query="StatenIsland, NY",
+            min_price="",
+            max_price="",
+            bed_num="",
+        )
+        query_result_dict = {
+            "locality__iexact": "Staten Island",
+            "state__iexact": "NY",
+            "apartment_set__is_rented": False,
+        }
+        query_result_apa_dict = {"is_rented": False}
+
+        self.assertDictEqual(q_loc, query_result_dict)
+        self.assertDictEqual(q_apa, query_result_apa_dict)
+
+    def test_build_query_locality_mismatch_no_state(self):
+        """
+        Tests the return value of build_search_query when
+        the address locality is in the original query
+        """
+
+        addr = Address.from_dict(
+            {
+                "street": "",
+                "zipcode": "",
+                "city": "Staten Island",
+                "state": "NY",
+                "latitude": 40.6195067,
+                "longitude": -73.9859414,
+                "locality": "Staten Island",
+            }
+        )
+
+        q_loc, q_apa = build_search_query(
+            address=addr,
+            orig_query="StatenIsland",
+            min_price="",
+            max_price="",
+            bed_num="",
+        )
+        query_result_dict = {
+            "locality__iexact": "Staten Island",
+            "state__iexact": "NY",
+            "apartment_set__is_rented": False,
+        }
+        query_result_apa_dict = {"is_rented": False}
+
+        self.assertDictEqual(q_loc, query_result_dict)
+        self.assertDictEqual(q_apa, query_result_apa_dict)
+
     def test_build_query_if_address(self):
         """
         test building the address string

--- a/search/tests.py
+++ b/search/tests.py
@@ -559,3 +559,32 @@ class SearchQueryBuilderTests(TestCase):
         query_result_apa_dict = {"is_rented": False, "number_of_bed": "1"}
         self.assertDictEqual(q_loc, query_result_dict)
         self.assertDictEqual(q_apa, query_result_apa_dict)
+
+    def test_build_query_city_mismatch(self):
+        """
+        test building the address string with a mispelled city name
+        """
+        addr = Address.from_dict(
+            {
+                "street": "",
+                "zipcode": "",
+                "city": "Bay Ridge",
+                "state": "NY",
+                "latitude": 0.0,
+                "longitude": 0.0,
+                "locality": "Brooklyn",
+            }
+        )
+
+        q_loc, q_apa = build_search_query(
+            address=addr, orig_query="bayridge", min_price="", max_price="", bed_num=""
+        )
+        query_result_dict = {
+            "city__iexact": "Bay Ridge",
+            "state__iexact": "NY",
+            "apartment_set__is_rented": False,
+        }
+        query_result_apa_dict = {"is_rented": False}
+
+        self.assertDictEqual(q_loc, query_result_dict)
+        self.assertDictEqual(q_apa, query_result_apa_dict)

--- a/search/views.py
+++ b/search/views.py
@@ -208,7 +208,7 @@ def build_search_query(address, min_price, max_price, bed_num, orig_query):
     elif address:
         # filter based on existence of locations with the specified address
         if address.street:
-            query_params_location["address__iexact"] = address.street
+            query_params_location["address__icontains"] = address.street
         if address.city or address.locality:
             if (
                 address.city
@@ -216,14 +216,11 @@ def build_search_query(address, min_price, max_price, bed_num, orig_query):
                 and address.locality.lower() in orig_query.lower()
             ):
                 query_params_location["locality__iexact"] = address.locality
-                # if the locality AND the zip code are in the orig_query
-                # search on locality, not city
             elif (
-                address.city.replace(" ", "").lower()
-                not in orig_query.replace(" ", "").lower()
-            ):
-                query_params_location["locality__iexact"] = address.locality
-            else:  # default to city
+                address.city
+                and address.city.replace(" ", "").lower()
+                in orig_query.replace(" ", "").lower()
+            ):  # default to city
                 # to include "brooklyn", "Brooklyn" etc. (case-insensitive)
                 query_params_location["city__iexact"] = address.city
         if address.state:

--- a/search/views.py
+++ b/search/views.py
@@ -201,6 +201,10 @@ def build_search_query(address, min_price, max_price, bed_num, orig_query):
     query_params_location = {}
     query_params_apartment = {}
 
+    # Useful for Debugging
+    # print(f"address: {address}"
+    # f"query: {orig_query}")
+
     # if the original query, exactly matches the zipcode, we want to only search
     # on the zip code
     if address and address.zipcode and address.zipcode == orig_query:
@@ -213,7 +217,8 @@ def build_search_query(address, min_price, max_price, bed_num, orig_query):
             if (
                 address.city
                 and address.locality
-                and address.locality.lower() in orig_query.lower()
+                and address.locality.replace(" ", "").lower()
+                in orig_query.replace(" ", "").lower()
             ):
                 query_params_location["locality__iexact"] = address.locality
             elif (

--- a/search/views.py
+++ b/search/views.py
@@ -218,7 +218,10 @@ def build_search_query(address, min_price, max_price, bed_num, orig_query):
                 query_params_location["locality__iexact"] = address.locality
                 # if the locality AND the zip code are in the orig_query
                 # search on locality, not city
-            elif address.city.lower() not in orig_query.lower():
+            elif (
+                address.city.replace(" ", "").lower()
+                not in orig_query.replace(" ", "").lower()
+            ):
                 query_params_location["locality__iexact"] = address.locality
             else:  # default to city
                 # to include "brooklyn", "Brooklyn" etc. (case-insensitive)


### PR DESCRIPTION
This fixes the issue where searching for address strings like "bayridge" returned results in all of brooklyn instead of just in Bay Ridge.  

Basically I fixed this in line 222-223 of `search/views.py`. My strategy was when checking that the City name was not in the original search query, to remove all spaces so even when a user searches for "bayridge" it would match even if the Geocode Address result was "Bay Ridge".

This seems to work for this particular bug, but I'm not sure that this is the best way to do it or if it opens up other potential issues.  

I also added a missing test to the Review package. It's not part of this story but it's a tiny test case so I thought I'd might as well add it in.